### PR TITLE
chore/db(TASK-008): docker-compose로 로컬 MariaDB 재현성 구성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example only. Copy to ".env" and change values for local use.
+# DO NOT COMMIT real secrets.
+MARIADB_DATABASE=ticketing_flyway
+MARIADB_USER=ticketing_user
+MARIADB_PASSWORD=ticketing_pw
+MARIADB_ROOT_PASSWORD=root_pw

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,9 @@ out/
 src/main/resources/application-dev.yml
 
 # local env files
-*.env
 .env
+.env.*
+!.env.example
 
 *.log
 logs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mariadb:
+    image: mariadb:11
+    container_name: ticketing-mariadb
+    ports:
+      - "3306:3306"
+    env_file:
+      - .env
+    environment:
+      MARIADB_DATABASE: ${MARIADB_DATABASE}
+      MARIADB_USER: ${MARIADB_USER}
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
+      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "127.0.0.1", "-u", "${MARIADB_USER}", "-p${MARIADB_PASSWORD}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  mariadb_data:

--- a/docs/db/README.md
+++ b/docs/db/README.md
@@ -23,6 +23,41 @@
 * User: `ticketing_user`
 * 권한: 해당 DB에 대한 DDL/DML 권한
 
+### A) docker-compose (추천)
+
+프로젝트 루트의 `docker-compose.yml` + `.env`로 로컬 DB를 재현합니다.
+
+#### 1) `.env` 준비
+
+```bash
+cp .env.example .env
+````
+
+> 주의: `.env`는 로컬 전용이며 git에 커밋하지 않습니다.
+
+#### 2) DB 실행
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+#### 3) 애플리케이션 실행(dev)
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+#### 4) 검증
+
+```bash
+curl -i http://localhost:8080/health/db
+```
+
+---
+
+### B) 수동으로 DB/User 생성 (옵션)
+
 예시 SQL:
 
 ```sql
@@ -105,7 +140,7 @@ logging:
 
 ```bash
 ./gradlew clean test
-./gradlew bootRun -Dspring.profiles.active=dev
+./gradlew bootRun --args='--spring.profiles.active=dev'
 ```
 
 ### 정상 적용 확인


### PR DESCRIPTION
## What

* docker-compose로 로컬 MariaDB 구동 환경 추가
  * `docker-compose.yml` (MariaDB 서비스 + volume + healthcheck)
  * `.env.example` 추가(샘플 환경변수)
  * `.env`는 `.gitignore`로 제외
* dev 프로파일 DB 설정 정합
  * `application-dev.yml`에서 로컬 DB(`ticketing_flyway`) 연결 정보 정리
* 문서 업데이트
  * `docs/db/README.md`에 docker-compose 기반 로컬 실행 절차 추가

## Why

* 로컬에서도 `docker compose up -d`만으로 DB를 재현 가능하게 해 환경 차이로 인한 실패를 줄이기 위함
* Flyway 기반 스키마 버전관리 흐름을 유지하면서, 새 PC/새 환경에서도 동일한 실행 경험을 제공하기 위함

## How

* Docker Compose
  * MariaDB 컨테이너 healthcheck 적용으로 기동 안정성 확보
  * volume(`mariadb_data`)로 로컬 데이터 유지
  * `.env.example` 제공 + `.env`는 커밋되지 않도록 처리
* Dev profile
  * compose에서 생성한 DB/User에 맞춰 datasource 설정 정리

## Test

* Docker
  * `docker compose down -v && docker compose up -d`
  * `docker compose ps`에서 `healthy` 확인
* App(dev)
  * `./gradlew bootRun --args='--spring.profiles.active=dev'`
  * `curl -i http://localhost:8080/health/db` → `200 ok`

## Notes

* compose 파일
  * `docker-compose.yml`
* env 샘플
  * `.env.example` (`.env`는 gitignore)
* DB 문서
  * `docs/db/README.md`

closes #15