### PR TITLE
db(TASK-009): 티켓팅 도메인 스키마 및 시드 데이터 추가

### DIFF
--- a/docs/db/README.md
+++ b/docs/db/README.md
@@ -208,3 +208,72 @@ public String healthDb() {
 
 * `spring-boot-starter-flyway`: 애플리케이션 시작 시 Flyway 자동 실행
 * `flyway-mysql`: MariaDB/MySQL 호환 지원
+
+---
+
+## 7) Ticketing Schema (V3 / V4)
+
+티켓팅 도메인 기초 스키마는 `V3__ticketing_schema.sql`, seed 데이터는 `V4__seed_ticketing.sql`로 관리합니다.
+
+### 추가된 테이블
+
+* `event`
+  * 공연 기본 정보
+* `showtime`
+  * 공연 회차 정보
+* `seat`
+  * 좌석 마스터 정보
+  * 좌석 번호(`A1~A20`)와 좌석 등급(`VIP / R / S`) 관리
+* `seat_grade_price`
+  * 공연별 좌석 등급 가격 정보
+* `showtime_seat`
+  * 회차별 좌석 상태 정보
+
+### 설계 의도
+
+티켓팅 도메인에서는 같은 좌석이라도 회차마다 예약 상태가 달라질 수 있으므로, 좌석 마스터와 회차별 좌석 상태를 분리했습니다.
+
+* `seat`
+  * 좌석 자체의 고정 정보(좌석 번호, 등급)
+* `seat_grade_price`
+  * 공연별 좌석 등급 가격 정책
+* `showtime_seat`
+  * 회차별 좌석 상태(`AVAILABLE`, `HELD`, `RESERVED`)
+
+예를 들어 같은 `A1` 좌석이라도:
+
+* 3/10 19:00 회차에서는 `RESERVED`
+* 3/11 19:00 회차에서는 `AVAILABLE`
+
+상태가 다를 수 있으므로 `showtime_seat`에서 별도로 관리합니다.
+
+### Seed 데이터
+
+`V4__seed_ticketing.sql` 기준으로 아래 데이터가 입력됩니다.
+
+* `event` : 1건
+* `showtime` : 2건
+* `seat` : 20건 (`A1 ~ A20`)
+* `seat_grade_price` : 3건 (`VIP / R / S`)
+* `showtime_seat` : 40건 (`2회차 × 20좌석`, 초기값 `AVAILABLE`)
+
+### 확인 포인트
+
+애플리케이션을 dev 프로필로 실행한 뒤 DBeaver에서 아래를 확인합니다.
+
+* `event` 1건
+* `showtime` 2건
+* `seat` 20건
+* `seat_grade_price` 3건
+* `showtime_seat` 40건
+
+추가로 아래 값도 확인합니다.
+
+* `seat.grade` → `VIP / R / S`
+* `showtime_seat.status` → 초기값 `AVAILABLE`
+
+### 주의사항
+
+* 기존 migration(`V1`, `V2`)은 수정하지 않고, 변경 사항은 새 버전(`V3`, `V4`)으로 추가합니다.
+* Flyway가 이미 적용한 migration 파일을 수정하면 checksum mismatch가 발생할 수 있습니다.
+* 로컬 개발 중 migration 수정이 필요할 경우, DB를 초기화한 뒤 다시 실행해 검증합니다.

--- a/src/main/resources/db/migration/V3__ticketing_schema.sql
+++ b/src/main/resources/db/migration/V3__ticketing_schema.sql
@@ -1,0 +1,59 @@
+CREATE TABLE event (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL COMMENT '공연명',
+    venue VARCHAR(100) NOT NULL COMMENT '공연장명',
+    status VARCHAR(30) NOT NULL COMMENT '공연 상태(예: ON_SALE, CLOSED)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id)
+) COMMENT='공연 기본 정보';
+
+CREATE TABLE showtime (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id BIGINT NOT NULL COMMENT '공연 ID',
+    show_at DATETIME NOT NULL COMMENT '공연 시작 일시',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id),
+    CONSTRAINT fk_showtime_event FOREIGN KEY (event_id) REFERENCES event(id)
+) COMMENT='공연 회차 정보';
+
+CREATE TABLE seat (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    seat_number VARCHAR(20) NOT NULL COMMENT '좌석 표시 번호(A1, A2 등)',
+    grade VARCHAR(20) NOT NULL COMMENT '좌석 등급(VIP, R, S)',
+    row_label VARCHAR(10) NOT NULL COMMENT '좌석 열 구분(A, B 등)',
+    seat_no INT NOT NULL COMMENT '좌석 번호(1, 2, 3 등)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id),
+    CONSTRAINT uk_seat_number UNIQUE (seat_number)
+) COMMENT='좌석 마스터 정보';
+
+CREATE TABLE seat_grade_price (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id BIGINT NOT NULL COMMENT '공연 ID',
+    grade VARCHAR(20) NOT NULL COMMENT '좌석 등급(VIP, R, S)',
+    price INT NOT NULL COMMENT '등급별 가격',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id),
+    CONSTRAINT fk_seat_grade_price_event FOREIGN KEY (event_id) REFERENCES event(id),
+    CONSTRAINT uk_event_grade UNIQUE (event_id, grade)
+) COMMENT='공연별 좌석 등급 가격 정보';
+
+CREATE TABLE showtime_seat (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    showtime_id BIGINT NOT NULL COMMENT '공연 회차 ID',
+    seat_id BIGINT NOT NULL COMMENT '좌석 ID',
+    status VARCHAR(20) NOT NULL COMMENT '좌석 상태(AVAILABLE, HELD, RESERVED)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
+    PRIMARY KEY (id),
+    CONSTRAINT fk_showtime_seat_showtime FOREIGN KEY (showtime_id) REFERENCES showtime(id),
+    CONSTRAINT fk_showtime_seat_seat FOREIGN KEY (seat_id) REFERENCES seat(id),
+    CONSTRAINT uk_showtime_seat UNIQUE (showtime_id, seat_id)
+) COMMENT='회차별 좌석 상태 정보';
+
+CREATE INDEX idx_showtime_seat_showtime_status
+    ON showtime_seat (showtime_id, status);

--- a/src/main/resources/db/migration/V4__seed_ticketing.sql
+++ b/src/main/resources/db/migration/V4__seed_ticketing.sql
@@ -1,0 +1,46 @@
+INSERT INTO event (name, venue, status)
+VALUES ('Concert 2026', 'Seoul Arena', 'ON_SALE');
+
+INSERT INTO showtime (event_id, show_at)
+VALUES
+    (1, '2026-03-10 19:00:00'),
+    (1, '2026-03-11 19:00:00');
+
+INSERT INTO seat (seat_number, grade, row_label, seat_no)
+VALUES
+    ('A1', 'VIP', 'A', 1),
+    ('A2', 'VIP', 'A', 2),
+    ('A3', 'VIP', 'A', 3),
+    ('A4', 'VIP', 'A', 4),
+    ('A5', 'R', 'A', 5),
+    ('A6', 'R', 'A', 6),
+    ('A7', 'R', 'A', 7),
+    ('A8', 'R', 'A', 8),
+    ('A9', 'R', 'A', 9),
+    ('A10', 'R', 'A', 10),
+    ('A11', 'S', 'A', 11),
+    ('A12', 'S', 'A', 12),
+    ('A13', 'S', 'A', 13),
+    ('A14', 'S', 'A', 14),
+    ('A15', 'S', 'A', 15),
+    ('A16', 'S', 'A', 16),
+    ('A17', 'S', 'A', 17),
+    ('A18', 'S', 'A', 18),
+    ('A19', 'S', 'A', 19),
+    ('A20', 'S', 'A', 20);
+
+INSERT INTO seat_grade_price (event_id, grade, price)
+VALUES
+    (1, 'VIP', 150000),
+    (1, 'R', 120000),
+    (1, 'S', 90000);
+
+INSERT INTO showtime_seat (showtime_id, seat_id, status)
+SELECT 1, id, 'AVAILABLE'
+FROM seat
+ORDER BY id;
+
+INSERT INTO showtime_seat (showtime_id, seat_id, status)
+SELECT 2, id, 'AVAILABLE'
+FROM seat
+ORDER BY id;


### PR DESCRIPTION
## What

* Flyway 기반 티켓팅 도메인 스키마 추가
  * `V3__ticketing_schema.sql`
    * `event`
    * `showtime`
    * `seat`
    * `seat_grade_price`
    * `showtime_seat`
  * 테이블/컬럼 comment 추가
  * 제약/인덱스 추가
    * `showtime_seat(showtime_id, seat_id)` UNIQUE
    * `showtime_seat(showtime_id, status)` INDEX
    * `seat_grade_price(event_id, grade)` UNIQUE
* 티켓팅 seed 데이터 추가
  * `V4__seed_ticketing.sql`
    * event 1건
    * showtime 2건
    * seat 20건 (`A1~A20`)
    * seat_grade_price 3건 (`VIP / R / S`)
    * showtime_seat 40건 (`2회차 × 20좌석`, 초기값 `AVAILABLE`)
* 문서 업데이트
  * `docs/db/README.md`에 V3/V4 티켓팅 스키마 및 seed 데이터 설명 추가

## Why

* 티켓팅 도메인 구현 전, 공연/회차/좌석/가격/회차별 좌석 상태를 DB 레벨에서 먼저 확정하기 위함
* 좌석 마스터, 공연별 가격 정책, 회차별 좌석 상태를 분리해 이후 조회/선점(HOLD)/예약 기능으로 자연스럽게 확장하기 위함
* dev 실행 시 Flyway로 동일한 티켓팅 기초 데이터가 자동 구성되도록 해 로컬 재현성을 유지하기 위함

## How

* Ticketing schema
  * `seat`에 좌석 번호와 등급(`VIP / R / S`)을 저장
  * `seat_grade_price`로 공연별 좌석 등급 가격을 분리
  * `showtime_seat`로 회차별 좌석 상태(`AVAILABLE`, `HELD`, `RESERVED`)를 관리
* Seed data
  * 단일 공연 + 2개 회차 + 20개 좌석 + 등급별 가격 + 회차별 좌석 상태를 초기 데이터로 구성
  * `showtime_seat`는 `INSERT ... SELECT`로 회차별 좌석 상태를 초기화
* Documentation
  * 테이블 역할, 설계 의도, seed 데이터 구성 및 확인 포인트를 문서에 반영

## Test

* Local DB
  * `ticketing_flyway` DB 초기화 후 재생성
* App(dev)
  * `./gradlew bootRun --args='--spring.profiles.active=dev'`
  * Flyway V1~V4 적용 확인
* DB 확인
  * DBeaver에서 아래 건수 확인
    * `event` 1건
    * `showtime` 2건
    * `seat` 20건
    * `seat_grade_price` 3건
    * `showtime_seat` 40건
* Health Check
  * `curl -i http://localhost:8080/health/db` → `200 ok`

## Notes

* migration 파일
  * `src/main/resources/db/migration/V3__ticketing_schema.sql`
  * `src/main/resources/db/migration/V4__seed_ticketing.sql`
* 문서
  * `docs/db/README.md`
* 로컬에서 기존 migration 수정 후 재실행 시 checksum mismatch가 발생할 수 있어 DB 초기화 후 재검증함

closes #17