### PR TITLE
chore(TASK-019-1): Spring Boot 4.x → 3.4.3 다운그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '4.0.3'
+  id 'org.springframework.boot' version '3.4.3'
   id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -30,7 +30,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
-  implementation 'org.springframework.boot:spring-boot-starter-flyway'
+  implementation 'org.flywaydb:flyway-core'
   implementation 'org.flywaydb:flyway-mysql' // MariaDB/MySQL 호환용 (권장)
 
   compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## What
* Spring Boot `4.0.3` → `3.4.3` 다운그레이드
* `spring-boot-starter-flyway` → `org.flywaydb:flyway-core` 교체

## Why
* TASK-019 Redis 분산락 작업 중 `redisson-spring-boot-starter`가
  Spring Boot 4.x와 호환되지 않는 문제 발견
  * `ClassNotFoundException: RedisAutoConfiguration` 발생
* Spring Boot 4.x는 아직 실무 도입 사례가 거의 없고
  주요 라이브러리들의 호환성이 안정적이지 않음
* Spring Boot 3.x가 현재 실무 표준이며 라이브러리 호환성이 안정적

## Test
* `./gradlew clean test -Dspring.profiles.active=test` 통과

## Notes
* 이후 TASK-019에서 Redisson 의존성 추가 예정

closes #38