### PR TITLE
docs(TASK-024): ERD reservations hold_id FK UK 표기 수정

### DIFF
--- a/docs/db/erd/README.md
+++ b/docs/db/erd/README.md
@@ -70,7 +70,7 @@ erDiagram
 
     reservations {
         bigint id PK
-        bigint hold_id FK UK "NOT NULL"
+        bigint hold_id FK "NOT NULL UK - HOLD 1:1 예약 보장"
         bigint showtime_id FK "NOT NULL"
         bigint seat_id FK "NOT NULL"
         bigint member_id FK "NOT NULL"


### PR DESCRIPTION
## What
- `docs/db/erd/README.md`: reservations 테이블 `hold_id FK UK` → `hold_id FK "NOT NULL UK - HOLD 1:1 예약 보장"` 표기 수정

## Why
- Mermaid erDiagram은 키 타입을 하나만 지원하여 `FK UK` 동시 표기 시 파싱 에러 발생
- GitHub에서 ERD 렌더링 실패 수정

## How
- `hold_id` 키 타입을 `FK` 단일로 유지하고 UK 제약조건은 컬럼 주석으로 표기

## Test
- [x] GitHub에서 `docs/db/erd/README.md` ERD 정상 렌더링 확인

## Notes
> 없음

closes #55 