### PR TITLE
feat(TASK-036-1): 결제 실패/환불 처리 - HOLD/좌석 자동 복구

### DIFF
--- a/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
+++ b/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
@@ -9,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "7. Payment", description = "결제 API - Mock 결제 처리")
 @RestController
@@ -27,7 +24,7 @@ public class PaymentController {
    * 이 API의 목적:
    * - Mock 결제를 처리한다.
    * - 결제 성공 시 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다.
-   * - 결제 실패 시 예약 FAILED로 전환된다.
+   * - 결제 실패 시 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구된다.
    * - forceFailure: true이면 강제 실패 처리 (Mock 결제 실패 시나리오 재현용)
    * <p>
    * Idempotency-Key 정책:
@@ -37,9 +34,6 @@ public class PaymentController {
    * <p>
    * 상태코드 정책:
    * - 결제 처리 성공 시 201 Created
-   * <p>
-   * 응답 정책:
-   * - 표준 응답 포맷(ApiResponse)로 감싸서 반환
    */
   @PostMapping("/payments")
   public ResponseEntity<ApiResponse<PaymentResponse>> pay(
@@ -53,5 +47,26 @@ public class PaymentController {
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(ApiResponse.success(response));
+  }
+
+  /**
+   * POST /payments/{paymentId}/refund
+   * <p>
+   * 이 API의 목적:
+   * - 결제 성공(SUCCESS) 상태인 결제에 대해 환불을 처리한다.
+   * - 환불 시 Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE로 전환된다.
+   * - SUCCESS 상태가 아닌 결제 환불 시도 시 409 Conflict 반환 (PAYMENT-005)
+   * <p>
+   * 상태코드 정책:
+   * - 환불 처리 성공 시 200 OK
+   */
+  @PostMapping("/payments/{paymentId}/refund")
+  public ResponseEntity<ApiResponse<PaymentResponse>> refund(
+    @PathVariable Long paymentId) {
+
+    // Service 호출: 환불 처리
+    PaymentResponse response = paymentService.refund(paymentId);
+
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/pil97/ticketing/payment/api/dto/response/PaymentResponse.java
+++ b/src/main/java/com/pil97/ticketing/payment/api/dto/response/PaymentResponse.java
@@ -11,27 +11,39 @@ import java.time.LocalDateTime;
  * {
  * "paymentId": 1,
  * "status": "SUCCESS",
- * "paidAt": "2026-04-03T10:00:00"
+ * "paidAt": "2026-04-07T10:00:00",
+ * "refundedAt": null
  * }
  * JSON 예시(실패):
  * {
  * "paymentId": 2,
  * "status": "FAIL",
- * "paidAt": null
+ * "paidAt": null,
+ * "refundedAt": null
+ * }
+ * JSON 예시(환불):
+ * {
+ * "paymentId": 1,
+ * "status": "REFUNDED",
+ * "paidAt": "2026-04-07T10:00:00",
+ * "refundedAt": "2026-04-07T10:20:00"
  * }
  */
 public record PaymentResponse(
   Long paymentId,
   String status,
   // 결제 성공 시 완료 시각, 실패 시 null
-  LocalDateTime paidAt
+  LocalDateTime paidAt,
+  // 환불 완료 시각, 환불 전 null
+  LocalDateTime refundedAt
 ) {
   // Payment 엔티티를 응답 DTO로 변환
   public static PaymentResponse of(Payment payment) {
     return new PaymentResponse(
       payment.getId(),
       payment.getStatus().name(),
-      payment.getPaidAt()
+      payment.getPaidAt(),
+      payment.getRefundedAt()
     );
   }
 }

--- a/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
+++ b/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
@@ -33,8 +33,7 @@ public class PaymentService {
    * - Payment를 PENDING 상태로 저장한다
    * - forceFailure가 true이면 결제 실패 처리한다 (Redis 저장 안 함 - 재시도 허용)
    * - 결제 성공 시: Payment SUCCESS, 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED, Redis 저장
-   * - 결제 실패 시: Payment FAIL, 예약 FAILED
-   * - 좌석/HOLD 복구는 TASK-036-1에서 처리 예정
+   * - 결제 실패 시: Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE 복구
    * - 실운영 시 PG 콜백 기반 비동기 처리로 전환 필요
    *
    * @param idempotencyKey 클라이언트가 전달한 idempotency key
@@ -51,6 +50,42 @@ public class PaymentService {
     // 2) 동일 key로 재요청 시 Redis에서 기존 결과 반환 (DB 처리 없음)
     return idempotencyRedisRepository.find(idempotencyKey)
       .orElseGet(() -> processPayment(idempotencyKey, request));
+  }
+
+  /**
+   * 환불 처리
+   * - paymentId로 결제를 조회한다
+   * - SUCCESS 상태인 경우만 환불 가능 - 그 외 상태는 예외 발생
+   * - Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE 순서로 전환
+   *
+   * @param paymentId 환불 대상 결제 ID
+   * @return 환불 처리 결과 응답
+   */
+  @Transactional
+  public PaymentResponse refund(Long paymentId) {
+    // 1) 결제 존재 여부 확인
+    Payment payment = paymentRepository.findById(paymentId)
+      .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+    // 2) SUCCESS 상태인 경우만 환불 가능
+    if (payment.getStatus() != com.pil97.ticketing.payment.domain.PaymentStatus.SUCCESS) {
+      throw new BusinessException(PaymentErrorCode.REFUND_NOT_ALLOWED);
+    }
+
+    // 3) Payment 상태 REFUNDED 전환
+    payment.refund();
+
+    // 4) 예약 상태 CANCELLED 전환
+    Reservation reservation = payment.getReservation();
+    reservation.cancel();
+
+    // 5) HOLD 상태 EXPIRED 전환 - 기존 만료 스케줄러와 동일한 상태값 사용
+    reservation.getHold().expire();
+
+    // 6) 좌석 상태 AVAILABLE 전환
+    reservation.getHold().getShowtimeSeat().markAvailable();
+
+    return PaymentResponse.of(payment);
   }
 
   /**
@@ -73,6 +108,9 @@ public class PaymentService {
     if (request.isForceFailure()) {
       savedPayment.fail();
       reservation.fail();
+      // 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 복구
+      reservation.getHold().expire();
+      reservation.getHold().getShowtimeSeat().markAvailable();
       return PaymentResponse.of(savedPayment);
     }
 

--- a/src/main/java/com/pil97/ticketing/payment/domain/Payment.java
+++ b/src/main/java/com/pil97/ticketing/payment/domain/Payment.java
@@ -35,6 +35,10 @@ public class Payment {
   @Column(name = "paid_at")
   private LocalDateTime paidAt;
 
+  // 환불 완료 시각 - 환불 전 null
+  @Column(name = "refunded_at")
+  private LocalDateTime refundedAt;
+
   @Column(name = "created_at", insertable = false, updatable = false)
   private LocalDateTime createdAt;
 
@@ -61,5 +65,11 @@ public class Payment {
   // 결제 실패 처리 - 상태를 FAIL로 전환, paidAt은 null 유지
   public void fail() {
     this.status = PaymentStatus.FAIL;
+  }
+
+  // 환불 처리 - 상태를 REFUNDED로 전환하고 환불 시각 기록
+  public void refund() {
+    this.status = PaymentStatus.REFUNDED;
+    this.refundedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/pil97/ticketing/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/pil97/ticketing/payment/domain/PaymentStatus.java
@@ -6,5 +6,8 @@ public enum PaymentStatus {
   // 결제 성공
   SUCCESS,
   // 결제 실패
-  FAIL
+  FAIL,
+
+  // 환불 완료
+  REFUNDED
 }

--- a/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
@@ -8,7 +8,7 @@ import com.pil97.ticketing.common.error.ErrorCode;
 
 /**
  * 결제 도메인 에러코드
- * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: PAYMENT-004)
+ * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: PAYMENT-005)
  * 이 파일은 결제 도메인에서 발생하는 비즈니스 예외를 정의하는 enum입니다.
  */
 @Getter
@@ -25,7 +25,11 @@ public enum PaymentErrorCode implements ErrorCode {
   PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT-003", "Payment failed"),
 
   // Idempotency-Key 헤더 누락 시
-  IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "PAYMENT-004", "Idempotency-Key header is required");
+  IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "PAYMENT-004", "Idempotency-Key header is required"),
+
+  // SUCCESS 상태가 아닌 결제에 환불 시도 시
+  REFUND_NOT_ALLOWED(HttpStatus.CONFLICT, "PAYMENT-005", "Refund is only allowed for successful payments");
+
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -9,6 +9,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: ticketing-reservation-service
   profiles:
     active: dev
+  jackson:
+    time-zone: Asia/Seoul
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/db/migration/V14__add_refunded_at_to_payment.sql
+++ b/src/main/resources/db/migration/V14__add_refunded_at_to_payment.sql
@@ -1,0 +1,4 @@
+-- payment 테이블에 환불 완료 시각 컬럼 추가
+-- 환불 전 null, 환불 완료 시 refund() 호출 시각으로 채워진다
+ALTER TABLE payment
+  ADD COLUMN refunded_at DATETIME NULL AFTER paid_at;

--- a/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
@@ -76,7 +76,7 @@ class PaymentControllerTest {
     // given
     setAuthentication(42L);
     when(paymentService.pay(any(), any()))
-      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0)));
+      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -102,7 +102,7 @@ class PaymentControllerTest {
     // given
     setAuthentication(42L);
     when(paymentService.pay(any(), any()))
-      .thenReturn(new PaymentResponse(2L, "FAIL", null));
+      .thenReturn(new PaymentResponse(2L, "FAIL", null, null));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -118,7 +118,8 @@ class PaymentControllerTest {
       .andExpect(status().isCreated())
       .andExpect(jsonPath("$.success").value(true))
       .andExpect(jsonPath("$.data.status").value("FAIL"))
-      .andExpect(jsonPath("$.data.paidAt").doesNotExist());
+      .andExpect(jsonPath("$.data.paidAt").doesNotExist())
+      .andExpect(jsonPath("$.data.refundedAt").doesNotExist());
   }
 
   @Test
@@ -152,7 +153,7 @@ class PaymentControllerTest {
 
     // Redis에서 기존 결과 반환 시나리오
     when(paymentService.pay(eq("duplicate-key-001"), any()))
-      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0)));
+      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null));
 
     // when & then
     mockMvc.perform(post("/payments")

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
@@ -93,7 +93,7 @@ class PaymentServiceTest {
   }
 
   @Test
-  @DisplayName("pay: forceFailure=true이면 Payment FAIL, 예약 FAILED로 전환되고 Redis에 저장하지 않는다")
+  @DisplayName("pay: forceFailure=true이면 Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구된다")
   void pay_forceFailure() {
     // given
     String idempotencyKey = "test-key-002";
@@ -103,8 +103,13 @@ class PaymentServiceTest {
     when(request.getAmount()).thenReturn(150000);
     when(request.isForceFailure()).thenReturn(true);
 
+    ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
+    Hold hold = mock(Hold.class);
+    when(hold.getShowtimeSeat()).thenReturn(showtimeSeat);
+
     Reservation reservation = mock(Reservation.class);
     when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
+    when(reservation.getHold()).thenReturn(hold);
     when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
 
     Payment savedPayment = mock(Payment.class);
@@ -113,7 +118,6 @@ class PaymentServiceTest {
     when(savedPayment.getPaidAt()).thenReturn(null);
     when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
 
-    // idempotency key 최초 요청 - Redis miss
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when
@@ -126,6 +130,10 @@ class PaymentServiceTest {
     verify(savedPayment).fail();
     verify(reservation).fail();
     verify(reservation, never()).confirm();
+
+    // 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 복구 검증
+    verify(hold).expire();
+    verify(showtimeSeat).markAvailable();
 
     // 결제 실패 시 Redis 저장 없음 검증 - 재시도 허용
     verify(idempotencyRedisRepository, never()).save(any(), any());
@@ -284,5 +292,86 @@ class PaymentServiceTest {
     // 재처리 시 DB 접근 발생 검증
     verify(reservationRepository).findById(1L);
     verify(paymentRepository).save(any(Payment.class));
+  }
+
+// ===================== 환불 케이스 =====================
+  @Test
+  @DisplayName("refund: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE로 전환된다")
+  void refund_success() {
+    // given
+    ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
+    Hold hold = mock(Hold.class);
+    when(hold.getShowtimeSeat()).thenReturn(showtimeSeat);
+
+    Reservation reservation = mock(Reservation.class);
+    when(reservation.getHold()).thenReturn(hold);
+
+    Payment payment = mock(Payment.class);
+    when(payment.getId()).thenReturn(1L);
+    when(payment.getStatus()).thenReturn(PaymentStatus.SUCCESS);
+    when(payment.getReservation()).thenReturn(reservation);
+    when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+
+    // when
+    paymentService.refund(1L);
+
+    // then
+    verify(payment).refund();
+    verify(reservation).cancel();
+    verify(hold).expire();
+    verify(showtimeSeat).markAvailable();
+  }
+
+  @Test
+  @DisplayName("refund: SUCCESS 상태가 아닌 결제 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
+  void refund_notSuccess_throwsBusinessException() {
+    // given
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn(PaymentStatus.FAIL);
+    when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.refund(1L))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED);
+      });
+
+    verify(payment, never()).refund();
+  }
+
+  @Test
+  @DisplayName("refund: 이미 환불된 결제 재환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
+  void refund_alreadyRefunded_throwsBusinessException() {
+    // given
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn(PaymentStatus.REFUNDED);
+    when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.refund(1L))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED);
+      });
+
+    verify(payment, never()).refund();
+  }
+
+  @Test
+  @DisplayName("refund: 존재하지 않는 paymentId 환불 시도 시 BusinessException(PAYMENT_NOT_FOUND)을 던진다")
+  void refund_paymentNotFound_throwsBusinessException() {
+    // given
+    when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.refund(999L))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.PAYMENT_NOT_FOUND);
+      });
   }
 }


### PR DESCRIPTION
## What
- `PaymentStatus`에 `REFUNDED` 상태 추가
- `PaymentErrorCode`에 `REFUND_NOT_ALLOWED(PAYMENT-005)` 추가
- `Payment` 엔티티에 `refundedAt` 컬럼 및 `refund()` 메서드 추가
- `PaymentResponse`에 `refundedAt` 필드 추가
- `PaymentService.processPayment()` 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 복구 로직 추가
- `PaymentService.refund()` 환불 처리 메서드 구현
- `PaymentController`에 `POST /payments/{paymentId}/refund` 엔드포인트 추가
- Flyway 마이그레이션 - `payment` 테이블에 `refunded_at` 컬럼 추가
- `PaymentServiceTest` 결제 실패 복구 및 환불 케이스 추가
- `application.yml`, `application-common.yml` 타임존 설정 누락 반영

## Why
- TASK-035에서 Mock 결제 구현 시 결제 실패 시 좌석이 HOLD 상태로 남아 다른 사용자가 예약 불가한 문제가 있었음
- 결제 실패 시 선점한 좌석을 즉시 반환해 다른 사용자가 예약할 수 있도록 복구 흐름이 필요
- 환불 시에도 동일하게 좌석 반환 흐름이 필요

## How
- 결제 실패 복구: `processPayment()` 내 `forceFailure` 분기에서 `hold.expire()`, `seat.markAvailable()` 호출
- 환불 처리: `refund()` 메서드를 별도로 분리, SUCCESS 상태 검증 후 Payment → 예약 → HOLD → 좌석 순서로 상태 전환
- HOLD 복구 시 `HoldStatus.EXPIRED` 사용 - 기존 만료 스케줄러와 동일한 상태값으로 일관성 유지
- 환불 응답에 `refundedAt` 추가해 클라이언트에서 환불 시점 확인 가능

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가된 테스트
  - `PaymentServiceTest`: 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 전환 검증 1개 케이스
  - `PaymentServiceTest`: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, 좌석 AVAILABLE 전환 검증 1개 케이스
  - `PaymentServiceTest`: SUCCESS 상태가 아닌 결제 환불 시도 시 예외 발생 1개 케이스
  - `PaymentServiceTest`: 이미 환불된 결제 재환불 시도 시 예외 발생 1개 케이스
  - `PaymentServiceTest`: 존재하지 않는 paymentId 환불 시도 시 예외 발생 1개 케이스
- 수동 테스트 (Postman)
  - `forceFailure=true` 결제 실패 후 좌석 AVAILABLE, HOLD EXPIRED 확인
  - 결제 성공 후 `POST /payments/7/refund` → Payment REFUNDED, refundedAt 채워짐 확인
  - 이미 환불된 결제 재환불 시도 → PAYMENT-005 409 Conflict 확인

## Notes
> 구현 후 특이사항
- 환불 API는 현재 인증 없이 paymentId만으로 호출 가능 - 실운영 시 본인 결제 여부 검증 로직 추가 필요
- 결제 실패 복구는 동기 처리 - 실운영 시 PG 콜백 기반 비동기 처리로 전환 필요

closes #68 