### PR TITLE
feat(TASK-021-1): 환불 API 본인 소유권 검증 구현

### DIFF
--- a/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
+++ b/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
@@ -1,6 +1,7 @@
 package com.pil97.ticketing.payment.api;
 
 import com.pil97.ticketing.common.response.ApiResponse;
+import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
 import com.pil97.ticketing.payment.application.PaymentService;
@@ -9,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "7. Payment", description = "결제 API - Mock 결제 처리")
@@ -20,30 +22,19 @@ public class PaymentController {
 
   /**
    * POST /payments
-   * <p>
-   * 이 API의 목적:
    * - Mock 결제를 처리한다.
    * - 결제 성공 시 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다.
    * - 결제 실패 시 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구된다.
    * - forceFailure: true이면 강제 실패 처리 (Mock 결제 실패 시나리오 재현용)
-   * <p>
-   * Idempotency-Key 정책:
-   * - 클라이언트가 UUID를 생성해 헤더에 담아 전송
-   * - 동일 key 재요청 시 기존 결과 반환 (DB 처리 없음)
-   * - 헤더 누락 시 400 에러 반환 (PAYMENT-004)
-   * <p>
-   * 상태코드 정책:
-   * - 결제 처리 성공 시 201 Created
+   * - Idempotency-Key 헤더 누락 시 400 에러 반환 (PAYMENT-004)
    */
   @PostMapping("/payments")
   public ResponseEntity<ApiResponse<PaymentResponse>> pay(
     @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
     @RequestBody @Valid CreatePaymentRequest request) {
 
-    // Service 호출: idempotency key 검증 + 결제 처리
     PaymentResponse response = paymentService.pay(idempotencyKey, request);
 
-    // 201 Created + 표준 응답
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(ApiResponse.success(response));
@@ -51,21 +42,17 @@ public class PaymentController {
 
   /**
    * POST /payments/{paymentId}/refund
-   * <p>
-   * 이 API의 목적:
    * - 결제 성공(SUCCESS) 상태인 결제에 대해 환불을 처리한다.
-   * - 환불 시 Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE로 전환된다.
-   * - SUCCESS 상태가 아닌 결제 환불 시도 시 409 Conflict 반환 (PAYMENT-005)
-   * <p>
-   * 상태코드 정책:
-   * - 환불 처리 성공 시 200 OK
+   * - 본인 소유 결제가 아닌 경우 403 반환 (PAYMENT-006)
+   * - SUCCESS 상태가 아닌 결제 환불 시도 시 409 반환 (PAYMENT-005)
+   * - Controller는 요청/응답 변환만 담당 - 소유권 검증은 Service에서 처리
    */
   @PostMapping("/payments/{paymentId}/refund")
   public ResponseEntity<ApiResponse<PaymentResponse>> refund(
-    @PathVariable Long paymentId) {
+    @PathVariable Long paymentId,
+    @AuthenticationPrincipal Member loginMember) {
 
-    // Service 호출: 환불 처리
-    PaymentResponse response = paymentService.refund(paymentId);
+    PaymentResponse response = paymentService.refund(paymentId, loginMember);
 
     return ResponseEntity.ok(ApiResponse.success(response));
   }

--- a/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
+++ b/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
@@ -2,9 +2,11 @@ package com.pil97.ticketing.payment.application;
 
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
 import com.pil97.ticketing.payment.domain.Payment;
+import com.pil97.ticketing.payment.domain.PaymentStatus;
 import com.pil97.ticketing.payment.domain.repository.PaymentRepository;
 import com.pil97.ticketing.payment.error.PaymentErrorCode;
 import com.pil97.ticketing.reservation.domain.Reservation;
@@ -35,19 +37,13 @@ public class PaymentService {
    * - 결제 성공 시: Payment SUCCESS, 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED, Redis 저장
    * - 결제 실패 시: Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE 복구
    * - 실운영 시 PG 콜백 기반 비동기 처리로 전환 필요
-   *
-   * @param idempotencyKey 클라이언트가 전달한 idempotency key
-   * @param request        결제 요청 DTO
-   * @return 결제 처리 결과 응답
    */
   @Transactional
   public PaymentResponse pay(String idempotencyKey, CreatePaymentRequest request) {
-    // 1) idempotency key 누락 검증
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
       throw new BusinessException(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING);
     }
 
-    // 2) 동일 key로 재요청 시 Redis에서 기존 결과 반환 (DB 처리 없음)
     return idempotencyRedisRepository.find(idempotencyKey)
       .orElseGet(() -> processPayment(idempotencyKey, request));
   }
@@ -56,36 +52,52 @@ public class PaymentService {
    * 환불 처리
    * - paymentId로 결제를 조회한다
    * - SUCCESS 상태인 경우만 환불 가능 - 그 외 상태는 예외 발생
+   * - 로그인한 사용자가 해당 결제의 소유자인지 검증한다
+   * 소유권 검증은 Service 레이어에서 처리 - "누가 환불할 수 있는가"는 비즈니스 규칙
    * - Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE 순서로 전환
-   *
-   * @param paymentId 환불 대상 결제 ID
-   * @return 환불 처리 결과 응답
    */
   @Transactional
-  public PaymentResponse refund(Long paymentId) {
+  public PaymentResponse refund(Long paymentId, Member loginMember) {
     // 1) 결제 존재 여부 확인
     Payment payment = paymentRepository.findById(paymentId)
       .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-    // 2) SUCCESS 상태인 경우만 환불 가능
-    if (payment.getStatus() != com.pil97.ticketing.payment.domain.PaymentStatus.SUCCESS) {
+    // 2) 소유권 검증 - 상태 검증보다 먼저 수행
+    //    소유권 검증을 먼저 해야 타인이 paymentId를 추측했을 때 결제 상태 정보가 노출되지 않는다
+    //    (상태 검증 먼저 시 409/403 응답 차이로 상태 유추 가능)
+    validateOwnership(payment, loginMember);
+
+    // 3) SUCCESS 상태인 경우만 환불 가능
+    if (payment.getStatus() != PaymentStatus.SUCCESS) {
       throw new BusinessException(PaymentErrorCode.REFUND_NOT_ALLOWED);
     }
 
-    // 3) Payment 상태 REFUNDED 전환
+    // 4) Payment 상태 REFUNDED 전환
     payment.refund();
 
-    // 4) 예약 상태 CANCELLED 전환
+    // 5) 예약 상태 CANCELLED 전환
     Reservation reservation = payment.getReservation();
     reservation.cancel();
 
-    // 5) HOLD 상태 EXPIRED 전환 - 기존 만료 스케줄러와 동일한 상태값 사용
+    // 6) HOLD 상태 EXPIRED 전환 - 기존 만료 스케줄러와 동일한 상태값 사용
     reservation.getHold().expire();
 
-    // 6) 좌석 상태 AVAILABLE 전환
+    // 7) 좌석 상태 AVAILABLE 전환
     reservation.getHold().getShowtimeSeat().markAvailable();
 
     return PaymentResponse.of(payment);
+  }
+
+  /**
+   * 결제 소유권 검증
+   * - Payment -> Reservation -> Member 체인으로 예약 소유자 ID 확인
+   * - 로그인 사용자와 예약 소유자가 다르면 403 예외 발생
+   */
+  private void validateOwnership(Payment payment, Member loginMember) {
+    Long ownerId = payment.getReservation().getMember().getId();
+    if (!ownerId.equals(loginMember.getId())) {
+      throw new BusinessException(PaymentErrorCode.REFUND_FORBIDDEN);
+    }
   }
 
   /**
@@ -93,40 +105,27 @@ public class PaymentService {
    * idempotency key 중복 확인 후 신규 요청일 때만 호출된다
    */
   private PaymentResponse processPayment(String idempotencyKey, CreatePaymentRequest request) {
-    // 1) 예약 존재 여부 확인
     Reservation reservation = reservationRepository.findById(request.getReservationId())
       .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
 
-    // 2) 결제 가능한 예약인지 검증 - PENDING 상태만 허용
     validatePayable(reservation);
 
-    // 3) Payment PENDING 상태로 저장
     Payment payment = Payment.create(reservation, request.getAmount());
     Payment savedPayment = paymentRepository.save(payment);
 
-    // 4) forceFailure가 true이면 강제 실패 처리 - Redis 저장 안 함 (재시도 허용)
     if (request.isForceFailure()) {
       savedPayment.fail();
       reservation.fail();
-      // 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 복구
       reservation.getHold().expire();
       reservation.getHold().getShowtimeSeat().markAvailable();
       return PaymentResponse.of(savedPayment);
     }
 
-    // 5) 결제 성공 처리
     savedPayment.success();
-
-    // 6) 예약 상태 CONFIRMED 전환
     reservation.confirm();
-
-    // 7) 좌석 상태 RESERVED 전환
     reservation.getHold().getShowtimeSeat().markReserved();
-
-    // 8) HOLD 상태 CONFIRMED 전환
     reservation.getHold().confirm();
 
-    // 9) 결제 성공 결과 Redis에 저장 (TTL 24시간)
     PaymentResponse response = PaymentResponse.of(savedPayment);
     idempotencyRedisRepository.save(idempotencyKey, response);
 

--- a/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
@@ -8,7 +8,7 @@ import com.pil97.ticketing.common.error.ErrorCode;
 
 /**
  * 결제 도메인 에러코드
- * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: PAYMENT-005)
+ * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: PAYMENT-006)
  * 이 파일은 결제 도메인에서 발생하는 비즈니스 예외를 정의하는 enum입니다.
  */
 @Getter
@@ -28,7 +28,10 @@ public enum PaymentErrorCode implements ErrorCode {
   IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "PAYMENT-004", "Idempotency-Key header is required"),
 
   // SUCCESS 상태가 아닌 결제에 환불 시도 시
-  REFUND_NOT_ALLOWED(HttpStatus.CONFLICT, "PAYMENT-005", "Refund is only allowed for successful payments");
+  REFUND_NOT_ALLOWED(HttpStatus.CONFLICT, "PAYMENT-005", "Refund is only allowed for successful payments"),
+
+  // 본인 소유가 아닌 결제에 환불 시도 시
+  REFUND_FORBIDDEN(HttpStatus.FORBIDDEN, "PAYMENT-006", "You are not allowed to refund this payment");
 
 
   private final HttpStatus status;

--- a/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
@@ -254,4 +254,69 @@ class PaymentControllerTest {
       .andExpect(jsonPath("$.success").value(false))
       .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED.getCode()));
   }
+
+// ────────────────────────────────────────────────
+  // POST /payments/{paymentId}/refund
+  // ────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("POST /payments/{paymentId}/refund: 환불 성공 → 200 + REFUNDED 반환")
+  void refund_success() throws Exception {
+    // given
+    setAuthentication(1L);
+    when(paymentService.refund(eq(1L), any(Member.class)))
+      .thenReturn(new PaymentResponse(1L, "REFUNDED", LocalDateTime.of(2026, 4, 6, 10, 0, 0), LocalDateTime.of(2026, 4, 7, 10, 0, 0)));
+
+    // when & then
+    mockMvc.perform(post("/payments/1/refund"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.success").value(true))
+      .andExpect(jsonPath("$.data.status").value("REFUNDED"))
+      .andExpect(jsonPath("$.data.refundedAt").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("POST /payments/{paymentId}/refund: 타인 결제 환불 시도 → 403 + PAYMENT-006 반환")
+  void refund_notOwner_returns403() throws Exception {
+    // given
+    setAuthentication(2L);
+    when(paymentService.refund(eq(1L), any(Member.class)))
+      .thenThrow(new BusinessException(PaymentErrorCode.REFUND_FORBIDDEN));
+
+    // when & then
+    mockMvc.perform(post("/payments/1/refund"))
+      .andExpect(status().isForbidden())
+      .andExpect(jsonPath("$.success").value(false))
+      .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.REFUND_FORBIDDEN.getCode()));
+  }
+
+  @Test
+  @DisplayName("POST /payments/{paymentId}/refund: SUCCESS 상태가 아닌 결제 환불 시도 → 409 + PAYMENT-005 반환")
+  void refund_notSuccess_returns409() throws Exception {
+    // given
+    setAuthentication(1L);
+    when(paymentService.refund(eq(1L), any(Member.class)))
+      .thenThrow(new BusinessException(PaymentErrorCode.REFUND_NOT_ALLOWED));
+
+    // when & then
+    mockMvc.perform(post("/payments/1/refund"))
+      .andExpect(status().isConflict())
+      .andExpect(jsonPath("$.success").value(false))
+      .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.REFUND_NOT_ALLOWED.getCode()));
+  }
+
+  @Test
+  @DisplayName("POST /payments/{paymentId}/refund: 존재하지 않는 paymentId → 404 + PAYMENT-001 반환")
+  void refund_paymentNotFound_returns404() throws Exception {
+    // given
+    setAuthentication(1L);
+    when(paymentService.refund(eq(999L), any(Member.class)))
+      .thenThrow(new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+    // when & then
+    mockMvc.perform(post("/payments/999/refund"))
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("$.success").value(false))
+      .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.PAYMENT_NOT_FOUND.getCode()));
+  }
 }

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
@@ -3,6 +3,7 @@ package com.pil97.ticketing.payment.application;
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
 import com.pil97.ticketing.payment.domain.Payment;
@@ -73,7 +74,6 @@ class PaymentServiceTest {
     when(savedPayment.getPaidAt()).thenReturn(null);
     when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
 
-    // idempotency key 최초 요청 - Redis miss
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when
@@ -87,8 +87,6 @@ class PaymentServiceTest {
     verify(showtimeSeat).markReserved();
     verify(hold).confirm();
     verify(savedPayment).success();
-
-    // 결제 성공 후 Redis 저장 검증
     verify(idempotencyRedisRepository).save(eq(idempotencyKey), any(PaymentResponse.class));
   }
 
@@ -130,12 +128,8 @@ class PaymentServiceTest {
     verify(savedPayment).fail();
     verify(reservation).fail();
     verify(reservation, never()).confirm();
-
-    // 결제 실패 시 HOLD EXPIRED, 좌석 AVAILABLE 복구 검증
     verify(hold).expire();
     verify(showtimeSeat).markAvailable();
-
-    // 결제 실패 시 Redis 저장 없음 검증 - 재시도 허용
     verify(idempotencyRedisRepository, never()).save(any(), any());
   }
 
@@ -148,8 +142,6 @@ class PaymentServiceTest {
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
     when(request.getReservationId()).thenReturn(999L);
     when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
-
-    // idempotency key 최초 요청 - Redis miss
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when & then
@@ -176,8 +168,6 @@ class PaymentServiceTest {
     Reservation reservation = mock(Reservation.class);
     when(reservation.getStatus()).thenReturn(ReservationStatus.CONFIRMED);
     when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
-
-    // idempotency key 최초 요청 - Redis miss
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when & then
@@ -191,7 +181,7 @@ class PaymentServiceTest {
     verifyNoInteractions(paymentRepository);
   }
 
-  // ===================== idempotency 신규 케이스 =====================
+  // ===================== idempotency 케이스 =====================
 
   @Test
   @DisplayName("pay: 동일 idempotency key 재요청 시 Redis에서 기존 결과를 반환하고 DB 처리를 하지 않는다")
@@ -201,7 +191,6 @@ class PaymentServiceTest {
 
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
 
-    // Redis에 기존 결과가 존재하는 상황
     PaymentResponse cachedResponse = mock(PaymentResponse.class);
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.of(cachedResponse));
 
@@ -210,8 +199,6 @@ class PaymentServiceTest {
 
     // then
     assertThat(response).isEqualTo(cachedResponse);
-
-    // DB 접근 없음 검증
     verifyNoInteractions(reservationRepository);
     verifyNoInteractions(paymentRepository);
   }
@@ -280,7 +267,6 @@ class PaymentServiceTest {
     when(savedPayment.getPaidAt()).thenReturn(null);
     when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
 
-    // 실패 후 재시도 - Redis에 저장된 값 없음 (실패는 저장 안 하므로)
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when
@@ -288,23 +274,30 @@ class PaymentServiceTest {
 
     // then
     assertThat(response.status()).isEqualTo("SUCCESS");
-
-    // 재처리 시 DB 접근 발생 검증
     verify(reservationRepository).findById(1L);
     verify(paymentRepository).save(any(Payment.class));
   }
 
-// ===================== 환불 케이스 =====================
+  // ===================== 환불 케이스 =====================
+
   @Test
   @DisplayName("refund: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE로 전환된다")
   void refund_success() {
     // given
+    // 로그인 사용자와 예약 소유자가 동일한 경우
+    Member loginMember = mock(Member.class);
+    when(loginMember.getId()).thenReturn(1L);
+
+    Member owner = mock(Member.class);
+    when(owner.getId()).thenReturn(1L);
+
     ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
     Hold hold = mock(Hold.class);
     when(hold.getShowtimeSeat()).thenReturn(showtimeSeat);
 
     Reservation reservation = mock(Reservation.class);
     when(reservation.getHold()).thenReturn(hold);
+    when(reservation.getMember()).thenReturn(owner);
 
     Payment payment = mock(Payment.class);
     when(payment.getId()).thenReturn(1L);
@@ -313,7 +306,7 @@ class PaymentServiceTest {
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
     // when
-    paymentService.refund(1L);
+    paymentService.refund(1L, loginMember);
 
     // then
     verify(payment).refund();
@@ -323,15 +316,56 @@ class PaymentServiceTest {
   }
 
   @Test
-  @DisplayName("refund: SUCCESS 상태가 아닌 결제 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
-  void refund_notSuccess_throwsBusinessException() {
+  @DisplayName("refund: 타인의 결제 환불 시도 시 BusinessException(REFUND_FORBIDDEN)을 던진다")
+  void refund_notOwner_throwsBusinessException() {
     // given
+    // 로그인 사용자(id=2)와 예약 소유자(id=1)가 다른 경우
+    Member loginMember = mock(Member.class);
+    when(loginMember.getId()).thenReturn(2L);
+
+    Member owner = mock(Member.class);
+    when(owner.getId()).thenReturn(1L);
+
+    Reservation reservation = mock(Reservation.class);
+    when(reservation.getMember()).thenReturn(owner);
+
     Payment payment = mock(Payment.class);
-    when(payment.getStatus()).thenReturn(PaymentStatus.FAIL);
+    when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
     // when & then
-    assertThatThrownBy(() -> paymentService.refund(1L))
+    assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_FORBIDDEN);
+      });
+
+    // 소유권 검증 실패 시 환불 처리 없음
+    verify(payment, never()).refund();
+  }
+
+  @Test
+  @DisplayName("refund: SUCCESS 상태가 아닌 결제 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
+  void refund_notSuccess_throwsBusinessException() {
+    // given
+    // 소유권 검증을 통과시키기 위해 로그인 사용자와 예약 소유자를 동일하게 설정
+    Member loginMember = mock(Member.class);
+    when(loginMember.getId()).thenReturn(1L);
+
+    Member owner = mock(Member.class);
+    when(owner.getId()).thenReturn(1L);
+
+    Reservation reservation = mock(Reservation.class);
+    when(reservation.getMember()).thenReturn(owner);
+
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn(PaymentStatus.FAIL);
+    when(payment.getReservation()).thenReturn(reservation);
+    when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
       .isInstanceOf(BusinessException.class)
       .satisfies(ex -> {
         BusinessException be = (BusinessException) ex;
@@ -345,12 +379,23 @@ class PaymentServiceTest {
   @DisplayName("refund: 이미 환불된 결제 재환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
   void refund_alreadyRefunded_throwsBusinessException() {
     // given
+    // 소유권 검증을 통과시키기 위해 로그인 사용자와 예약 소유자를 동일하게 설정
+    Member loginMember = mock(Member.class);
+    when(loginMember.getId()).thenReturn(1L);
+
+    Member owner = mock(Member.class);
+    when(owner.getId()).thenReturn(1L);
+
+    Reservation reservation = mock(Reservation.class);
+    when(reservation.getMember()).thenReturn(owner);
+
     Payment payment = mock(Payment.class);
     when(payment.getStatus()).thenReturn(PaymentStatus.REFUNDED);
+    when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
     // when & then
-    assertThatThrownBy(() -> paymentService.refund(1L))
+    assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
       .isInstanceOf(BusinessException.class)
       .satisfies(ex -> {
         BusinessException be = (BusinessException) ex;
@@ -364,10 +409,11 @@ class PaymentServiceTest {
   @DisplayName("refund: 존재하지 않는 paymentId 환불 시도 시 BusinessException(PAYMENT_NOT_FOUND)을 던진다")
   void refund_paymentNotFound_throwsBusinessException() {
     // given
+    Member loginMember = mock(Member.class);
     when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> paymentService.refund(999L))
+    assertThatThrownBy(() -> paymentService.refund(999L, loginMember))
       .isInstanceOf(BusinessException.class)
       .satisfies(ex -> {
         BusinessException be = (BusinessException) ex;


### PR DESCRIPTION
## What
- `PaymentErrorCode`에 `REFUND_FORBIDDEN(PAYMENT-006, 403)` 추가
- `PaymentService.refund()`에 `loginMember` 파라미터 추가 및 `validateOwnership()` 구현
- `PaymentController.refund()`에 `@AuthenticationPrincipal Member loginMember` 추가
- `PaymentServiceTest` 소유권 검증 케이스 2개 추가 및 기존 환불 케이스 수정
- `PaymentControllerTest` 환불 케이스 4개 신규 추가

## Why
- 기존 `POST /payments/{paymentId}/refund`는 JWT 인증은 되어 있으나 소유권 검증이 없어 인증된 사용자라면 타인의 결제도 환불 가능한 보안 취약점이 있었다.
- `Payment → Reservation → Member` 체인이 이미 구성되어 있어 추가 구조 변경 없이 검증 가능했다.

## How
- 소유권 검증은 Service 레이어에서 처리 — "누가 환불할 수 있는가"는 비즈니스 규칙이므로 Controller가 아닌 Service 책임
- 검증 순서를 `존재 여부 → 소유권 검증 → 상태 검증` 순으로 배치
  - 소유권 검증을 상태 검증보다 먼저 수행해 타인이 paymentId를 추측했을 때 결제 상태 정보(409 vs 403 응답 차이)가 노출되지 않도록 방어
- `@AuthenticationPrincipal`로 SecurityContext에서 현재 로그인 사용자를 주입
  - 현재 `Member` 엔티티를 직접 Principal로 사용 중 — `MemberPrincipal` DTO 분리는 TASK-054에서 처리 예정

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가된 테스트
  - `PaymentServiceTest`: 본인 환불 성공 / 타인 환불 403 케이스 2개 추가, 기존 상태 검증 케이스 소유권 mock 추가
  - `PaymentControllerTest`: 환불 성공 200 / 타인 403 / 상태오류 409 / 미존재 404 케이스 4개 추가
- 수동 테스트 (Postman)
  - 본인 토큰으로 본인 결제 환불 → 200 + REFUNDED 확인
  - 타인 토큰으로 타인 결제 환불 → 403 + PAYMENT-006 확인

## Notes
> - `QueueConcurrencyTest` 기존 실패 1건 존재 — TASK-029-1로 별도 처리 예정
> - `MemberPrincipal` DTO 분리 — TASK-054에서 처리 예정

closes #70 