### PR TITLE
fix(TASK-029-1): QueueConcurrencyTest Mockito stub 멀티스레드 불안정 버그 수정

### DIFF
--- a/src/test/java/com/pil97/ticketing/queue/application/QueueConcurrencyTest.java
+++ b/src/test/java/com/pil97/ticketing/queue/application/QueueConcurrencyTest.java
@@ -1,6 +1,5 @@
 package com.pil97.ticketing.queue.application;
 
-import com.pil97.ticketing.event.domain.repository.EventRepository;
 import com.pil97.ticketing.queue.application.scheduler.QueueScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +11,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -20,13 +18,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 /**
  * 테스트 흐름 설명
  * 1. 100개 스레드가 동시에 동일 이벤트 대기열에 등록 요청
  * 2. Redis Sorted Set ZADD NX로 각 memberId가 중복 없이 등록되는지 검증
  * 3. 등록된 유저 수 == 100, 순번 중복 없음 검증
+ * <p>
+ * EventRepository mock 제거 이유:
+ * - @BeforeEach의 Mockito stub은 메인 스레드 기준으로 등록되므로 워커 스레드에서 보장되지 않는다.
+ * - 동시성 테스트의 목적은 Redis Sorted Set 동시 접근 안정성 검증이므로 DB는 실제 환경을 사용한다.
+ * - @BeforeEach에서 jdbcTemplate으로 실제 seed 데이터의 eventId를 조회하므로 mock이 불필요하다.
  */
 @ActiveProfiles("test")
 @SpringBootTest
@@ -35,9 +37,6 @@ class QueueConcurrencyTest {
   // QueueScheduler가 테스트 중 실행되면 대기열에서 멤버를 제거해 순번 검증이 깨지므로 MockitoBean으로 비활성화
   @MockitoBean
   private QueueScheduler queueScheduler;
-
-  @MockitoBean
-  private EventRepository eventRepository;
 
   @Autowired
   private QueueService queueService;
@@ -52,7 +51,7 @@ class QueueConcurrencyTest {
 
   @BeforeEach
   void setUp() {
-    // seed 데이터 기준으로 첫 번째 이벤트 사용
+    // seed 데이터 기준으로 첫 번째 이벤트 사용 - 실제 DB에 존재하는 이벤트이므로 mock 불필요
     eventId = jdbcTemplate.queryForObject(
       "select id from event order by id limit 1", Long.class);
 
@@ -61,9 +60,8 @@ class QueueConcurrencyTest {
     redisTemplate.delete("queue:admitted:members:" + eventId);
     // seq 카운터 초기화 - 테스트 간 score 독립성 보장
     redisTemplate.delete("queue:seq:" + eventId);
-
-    // DB 조회 대신 항상 true 반환 - Redis 동시성 검증에 집중
-    when(eventRepository.existsById(eventId)).thenReturn(true);
+    // queue:active:events에서 해당 eventId 제거 - 테스트 간 잔여 데이터 방지
+    redisTemplate.opsForSet().remove("queue:active:events", String.valueOf(eventId));
   }
 
   @Test


### PR DESCRIPTION
## What
- `QueueConcurrencyTest`에서 `@MockitoBean EventRepository` 제거
- `when(eventRepository.existsById(eventId)).thenReturn(true)` 제거
- `@BeforeEach`에 `queue:active:events` 초기화 추가

## Why
- 동시성 테스트에서 두 가지 원인으로 간헐적 실패가 발생하고 있었다.

**원인 1 - Mockito stub 멀티스레드 불안정**
- `@BeforeEach`의 stub은 메인 스레드 기준으로 등록된다.
- Mockito는 멀티스레드 환경을 공식적으로 지원하지 않아 내부 상태 추적 로직이 스레드 안전하지 않다.
- `ExecutorService` 100개 워커 스레드에서 `existsById()` 호출 시 일부 스레드에서 stub이 `false`를 반환 → `EVENT_NOT_FOUND` 예외 발생 → `failCount` 증가 → `successCount != 100` 실패

**원인 2 - `queue:active:events` 초기화 누락**
- `@BeforeEach`에서 `queue:active:events` 초기화가 누락돼 이전 테스트 잔여 데이터가 남아 있었다.
- `@MockitoBean QueueScheduler`로 mock했음에도 `queue:active:events`에 잔여 eventId가 있으면 스케줄러가 실행돼 대기열에서 멤버를 제거 → 순번 검증 실패

## How
- `EventRepository` mock 제거 후 실제 DB 사용
  - `@SpringBootTest` 환경에서 test 프로파일 기준 13307 포트 ticketing_test DB에 직접 쿼리
  - DB는 멀티스레드 동시 접근에 안전하게 설계되어 있으므로 항상 일관된 결과 반환
  - `@BeforeEach`에서 이미 `jdbcTemplate`으로 실제 seed 데이터의 eventId를 조회하고 있으므로 mock 자체가 불필요했다
- `@BeforeEach`에 `queue:active:events` 초기화 추가로 테스트 간 Redis 상태 완전 격리

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 3회 연속 통과 확인

## Notes
> - 동시성 테스트에서 Mockito stub을 사용하면 테스트 자체가 신뢰할 수 없다는 점을 이 버그를 통해 확인
> - 이전 Flaky Test 수정(queue:seq 초기화)과 이번 수정은 원인이 다름 — 저번은 Redis 상태 초기화 누락, 이번은 Mockito 멀티스레드 설계 문제 + 또 다른 Redis 초기화 누락

closes #72 