### PR TITLE
docs(TASK-048): 아키텍처 의사결정 ADR 문서 작성

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -137,15 +137,28 @@ flowchart TD
 
 ## Redis Key 요약
 
-| Key                                    | 용도                  | TTL / 정리 방식                             |
-|----------------------------------------|---------------------|-----------------------------------------|
-| `refresh:{memberId}`                   | RefreshToken 저장     | 7일                                      |
-| `blacklist:{accessToken}`              | AccessToken 블랙리스트   | 잔여 만료 시간                                |
-| `events` 캐시 (`events::*`)              | 이벤트 목록 캐시           | 10분                                     |
-| `queue:event:{eventId}`                | 대기열 순번 (Sorted Set) | 이벤트 종료 시 key 삭제                         |
-| `token:user:{userId}`                  | 대기열 입장 토큰           | 30분                                     |
-| `hold:seat:{showtimeId}:{seatId}`      | 좌석 분산락              | Redisson leaseTime 기반 자동 해제             |
-| `idempotency:payment:{idempotencyKey}` | 결제 멱등성 키            | 24시간                                    |
-| `queue:active:events`                  | 활성 대기열 이벤트 목록 (Set) | 종료된 이벤트는 Set에서 제거                       |
-| `queue:admitted:members:{eventId}`     | 대기열 입장 허용 이력 (Set)  | 이벤트 종료 시 key 삭제                         |
-| `queue:seq:{eventId}`                  | 대기열 순번 카운터 (INCR)   | 현재 구현상 명시적 TTL 없음 / 종료 정리 코드에서 별도 삭제 없음 |
+| Key                                    | 용도                  | TTL / 정리 방식                                      |
+|----------------------------------------|---------------------|--------------------------------------------------|
+| `refresh:{memberId}`                   | RefreshToken 저장     | 7일                                               |
+| `blacklist:{accessToken}`              | AccessToken 블랙리스트   | 잔여 만료 시간                                         |
+| `events 캐시 (events::...)`              | 이벤트 목록 캐시           | 10분                                              | 
+| `queue:event:{eventId}`                | 대기열 순번 (Sorted Set) | 이벤트 종료 시 key 삭제                                  |
+| `token:user:{userId}`                  | 대기열 입장 토큰           | 30분                                              |
+| `hold:seat:{showtimeId}:{seatId}`      | 좌석 분산락              | Redisson leaseTime 기반 자동 해제                      |
+| `idempotency:payment:{idempotencyKey}` | 결제 멱등성 키            | 24시간                                             |
+| `queue:active:events`                  | 활성 대기열 이벤트 목록 (Set) | 종료된 이벤트는 Set에서 제거                                |
+| `queue:admitted:members:{eventId}`     | 대기열 입장 허용 이력 (Set)  | 이벤트 종료 시 key 삭제                                  |
+| `queue:seq:{eventId}`                  | 대기열 순번 카운터 (INCR)   | 현재 구현상 명시적 TTL 없음 / 종료 정리 정책은 TASK-057-1에서 보완 예정 |
+
+---
+
+## 4. 아키텍처 의사결정 기록 (ADR)
+
+핵심 설계 결정의 배경과 트레이드오프를 ADR(Architecture Decision Record) 형식으로 기록합니다.
+
+| ADR                                      | 제목                                            | 상태      |
+|------------------------------------------|-----------------------------------------------|---------|
+| [ADR-001](adr/ADR-001-no-kafka.md)       | Kafka 미도입 — 단일 트랜잭션 직접 상태 전환 유지               | Decided |
+| [ADR-002](adr/ADR-002-mock-payment.md)   | Mock 결제 — PG 연동 없이 forceFailure 플래그로 성공/실패 재현 | Decided |
+| [ADR-003](adr/ADR-003-no-outbox.md)      | Outbox Pattern 미적용 — 단일 트랜잭션으로 상태 일관성 유지      | Decided |
+| [ADR-004](adr/ADR-004-no-soft-delete.md) | Soft Delete 미적용 — 상태값으로 비활성 데이터 처리            | Decided |

--- a/docs/architecture/adr/ADR-001-no-kafka.md
+++ b/docs/architecture/adr/ADR-001-no-kafka.md
@@ -1,0 +1,51 @@
+# ADR-001: Kafka 미도입 — 단일 트랜잭션 직접 상태 전환 유지
+
+## Status
+
+Decided (2026-04) — 현재는 단일 트랜잭션 직접 상태 전환 유지, TASK-032에서 Spring Application
+Events 전환 검토 예정
+
+## Context
+
+티켓팅 서비스에서는 예약 확정, 결제 완료, 좌석 상태 변경 같은 후속 처리를 현재는 단일 트랜잭션 내 직접 상태 전환으로 처리하고 있다.
+향후 결합도 완화가 필요해질 경우 어떤 이벤트 처리 방식을 선택할지 함께 판단해야 했다.
+
+현재 프로젝트의 제약 조건은 다음과 같다.
+
+- 단일 Spring Boot 애플리케이션, 단일 MariaDB, 단일 JVM 환경
+- 서비스 분리(MSA) 계획 없음
+- 별도 Kafka 브로커 운영 인프라 없음
+
+## Decision
+
+Kafka를 도입하지 않는다. 현재는 Kafka와 Spring Events 모두 도입하지 않고 단일 `@Transactional` 경계 내에서
+Payment, Reservation, Hold, ShowtimeSeat 상태 전환을 직접 처리한다. Spring
+`ApplicationEventPublisher`는 TASK-032에서 결합도 완화가 필요해질 시점에 도입을 검토한다.
+
+## Consequences
+
+### Trade-offs
+
+| 항목       | 현재 방식 (직접 상태 전환)     | Kafka 도입 시                       |
+|----------|----------------------|----------------------------------|
+| 운영 복잡도   | 낮음                   | Kafka 브로커, ZooKeeper/KRaft 운영 필요 |
+| 트랜잭션 일관성 | DB 트랜잭션으로 원자성 보장     | 이벤트 발행과 DB 커밋 간 정합성 별도 처리 필요     |
+| 재처리 보장   | 없음                   | Consumer Group 기반 재처리 가능         |
+| 순서 보장    | 트랜잭션 내 순서 보장         | 파티션 단위 순서 보장                     |
+| 다중 소비자   | 불가                   | Consumer Group으로 확장 가능           |
+| 로컬 개발    | Docker Compose만으로 충분 | Kafka 컨테이너 추가 필요                 |
+
+### Future Path
+
+- TASK-032: Spring `ApplicationEventPublisher` 기반 이벤트 처리 도입
+  → 도메인 간 직접 의존 제거, 이벤트 리스너로 후속 처리 분리
+- 트래픽 급증 또는 서비스 분리 시점에 Kafka 전환 검토
+  → `ApplicationEventPublisher` 기반 구조를 먼저 정리하면, 이후 Kafka 전환 시 변경 범위를 줄일 수 있다.
+- Kafka 전환 시에는 Outbox Pattern(TASK-033)도 함께 적용하는 방향을 우선 검토한다.
+
+## Related Code / Docs
+
+- `payment/application/PaymentService.java` — 결제·예약·좌석 상태 전환 단일 트랜잭션 처리
+- `reservation/application/ReservationService.java` — 예약 생성 및 취소 트랜잭션 경계
+- `docs/architecture/adr/ADR-003-no-outbox.md` — Outbox 미적용 결정과 연계
+- 연계 TASK: TASK-032 (Spring Events 전환), TASK-033 (Outbox Pattern)

--- a/docs/architecture/adr/ADR-002-mock-payment.md
+++ b/docs/architecture/adr/ADR-002-mock-payment.md
@@ -1,0 +1,54 @@
+# ADR-002: Mock 결제 — PG 연동 없이 forceFailure 플래그로 성공/실패 재현
+
+## Status
+
+Decided (2026-04) — 실운영 전환 시 PaymentGateway 인터페이스 분리 후 구현체 교체 예정
+
+## Context
+
+티켓팅 서비스에서 예약→결제→확정 전체 흐름을 검증해야 한다.
+실 결제 처리를 위해서는 PG사(Payment Gateway) 계약, 샌드박스 환경, webhook 수신 서버가 필요하다.
+
+현재 프로젝트의 제약 조건은 다음과 같다.
+
+- 포트폴리오 목적의 백엔드 프로젝트로 PG 계약 및 샌드박스 환경 없음
+- 목표는 결제 성공/실패 시 예약·좌석·HOLD 상태 전환 흐름 검증
+- PG 콜백(비동기 webhook) 처리, 결제 타임아웃, 망취소 흐름은 현재 범위 밖
+
+## Decision
+
+실 PG 연동 없이 `PaymentService.pay()`에서 `forceFailure` 플래그로 결제 성공/실패를 재현한다.
+
+- `forceFailure = false`: Payment SUCCESS → Reservation CONFIRMED → ShowtimeSeat
+  RESERVED
+- `forceFailure = true`: Payment FAILED → Reservation FAILED → Hold EXPIRED →
+  ShowtimeSeat AVAILABLE
+
+현재는 포트폴리오 범위와 구현 복잡도를 고려해 `PaymentService`가 결제 처리를 직접 담당하며 외부 PG 추상화 계층은 아직 두지
+않았다.
+
+## Consequences
+
+### Trade-offs
+
+| 항목       | 현재 방식 (Mock)                    | 실 PG 연동 시                     |
+|----------|---------------------------------|-------------------------------|
+| 구현 복잡도   | 낮음                              | PG 어댑터, webhook 수신, 망취소 처리 필요 |
+| 흐름 검증    | 성공/실패 시나리오 재현 가능                | 실제 결제 네트워크 흐름 검증 가능           |
+| 비동기 처리   | 없음 (동기 처리)                      | PG 콜백 기반 비동기 처리 필요            |
+| 멱등성      | Redis idempotency key로 중복 요청 방지 | PG측 멱등성 키와 함께 이중 방어 필요        |
+| 타임아웃/망취소 | 미구현                             | 결제 타임아웃, 망취소 흐름 별도 처리 필요      |
+
+### Future Path
+- `PaymentGateway` 인터페이스를 추출하고 `MockPaymentGateway`, `PGPaymentGateway` 구현체로
+  분리한다. 이후 `PaymentService`가 인터페이스에만 의존하도록 리팩토링하면 PG 전환 시 변경 범위를 줄일 수 있다.
+
+- PG 전환 시 webhook 수신 엔드포인트, 결제 타임아웃 처리, 망취소 흐름 추가 구현 필요
+- 멱등성 키는 현재 구조 그대로 PG 연동 후에도 재사용 가능
+
+## Related Code / Docs
+
+- `payment/application/PaymentService.java` — forceFailure 플래그 기반 결제 처리 및 상태 전환
+- `infra/idempotency/IdempotencyRedisRepository.java` — 중복 결제 방지 Redis 멱등성 처리
+- `docs/architecture/adr/ADR-003-no-outbox.md` — 단일 트랜잭션 상태 전환과 연계
+- 연계 TASK: TASK-036 (결제 멱등성), TASK-036-1 (결제 실패/환불 처리)

--- a/docs/architecture/adr/ADR-003-no-outbox.md
+++ b/docs/architecture/adr/ADR-003-no-outbox.md
@@ -1,0 +1,55 @@
+# ADR-003: Outbox Pattern 미적용 — 단일 트랜잭션으로 상태 일관성 유지
+
+## Status
+
+Decided (2026-04) — 현재는 단일 트랜잭션 유지, TASK-033에서 Outbox Pattern 도입 검토 예정
+
+## Context
+
+결제 완료 시 Payment, Reservation, Hold, ShowtimeSeat 4개 엔티티의 상태가 함께 전환된다.
+이 상태 전환을 현재 구조에서 어떻게 일관되게 처리할지, 그리고 향후 외부 이벤트 발행이 필요해질 때 어떤 확장 경로를 가져갈지 결정해야 했다.
+
+Outbox Pattern은 DB 트랜잭션 내에 이벤트를 outbox 테이블에 함께 저장하고,
+별도 스케줄러가 이를 읽어 외부로 발행함으로써 이벤트 유실을 방지하는 패턴이다.
+
+현재 프로젝트의 제약 조건은 다음과 같다.
+
+- 외부 메시지 브로커(Kafka, RabbitMQ) 미도입
+- 단일 DB 트랜잭션으로 모든 상태 전환 원자성 보장 가능
+- 알림, 외부 시스템 연동 등 이벤트 발행 요건 없음
+
+## Decision
+
+Outbox Pattern을 적용하지 않는다.
+현재는 `PaymentService.pay()` 단일 `@Transactional` 경계 내에서
+Payment·Reservation·Hold·ShowtimeSeat 상태 전환을 직접 처리한다.
+
+외부 이벤트 발행 요건이 없는 현재 구조에서는 DB 트랜잭션만으로 원자성과 일관성을 보장할 수 있으므로 Outbox 테이블과 재처리 스케줄러를
+추가하지 않는다.
+
+## Consequences
+
+### Trade-offs
+
+| 항목        | 현재 방식 (단일 트랜잭션)  | Outbox Pattern 도입 시                |
+|-----------|------------------|------------------------------------|
+| 구현 복잡도    | 낮음               | Outbox 테이블, 발행 스케줄러, 재처리 로직 필요     |
+| 원자성 보장    | DB 트랜잭션으로 보장     | DB 저장 + 이벤트 발행 원자성 보장 가능           |
+| 이벤트 유실    | 외부 발행 없으므로 해당 없음 | 재처리 스케줄러로 유실 방지 가능                 |
+| 외부 시스템 연동 | 불가               | 브로커/외부 API 연동 가능                   |
+| 서비스 분리 대응 | 단일 서비스에서만 유효     | 서비스 분리 및 외부 이벤트 발행 요건이 생기면 유력한 선택지 |
+
+### Future Path
+
+- TASK-033: Outbox 테이블 추가와 재처리 스케줄러 도입을 검토한다.
+  → 외부 이벤트 발행 요건이 생기면 재처리 보장과 외부 시스템 연동을 위한 기반이 된다.
+- Outbox 도입 시 ADR-001에서 검토 중인 Spring Events와의 연계 적용도 함께 검토한다.
+  이벤트 저장(Outbox)과 후속 발행 구조를 분리하는 방향으로 확장할 수 있다.
+- 서비스 분리(MSA)와 외부 이벤트 발행 요건이 생기면 Outbox + Kafka 조합 도입을 우선 검토한다.
+
+## Related Code / Docs
+
+- `payment/application/PaymentService.java` — 단일 트랜잭션 내 4개 엔티티 상태 전환 처리
+- `docs/architecture/adr/ADR-001-no-kafka.md` — Kafka 미도입 결정과 연계
+- `docs/architecture/adr/ADR-002-mock-payment.md` — Mock 결제 트랜잭션 경계와 연계
+- 연계 TASK: TASK-033 (Outbox Pattern 도입 검토), TASK-032 (Spring Events 전환 검토)

--- a/docs/architecture/adr/ADR-004-no-soft-delete.md
+++ b/docs/architecture/adr/ADR-004-no-soft-delete.md
@@ -1,0 +1,57 @@
+# ADR-004: Soft Delete 미적용 — 상태값으로 비활성 데이터 처리
+
+## Status
+
+Decided (2026-04) — 감사 요건 발생 시 `@SQLDelete` + `@Where` 기반 전환 검토 예정
+
+## Context
+
+예약 취소, HOLD 만료, 결제 실패 등 비활성 데이터를 어떻게 처리할지 결정해야 했다.
+일반적으로 두 가지 방식이 있다.
+
+- Soft Delete: `deleted_at` 컬럼을 추가하고 DELETE 대신 UPDATE로 처리. 데이터 복구와 감사 이력 추적에 유리
+- 상태값 처리: `deleted_at` 없이 상태 Enum(`CANCELLED`, `EXPIRED`, `FAILED`)으로 비활성 상태를 표현
+
+현재 프로젝트의 제약 조건은 다음과 같다.
+
+- 예약·HOLD·결제 데이터를 물리 삭제하지 않고 상태로 관리하는 도메인 특성
+- 데이터 복구, 감사 로그, 규제 요건 없음
+- 상태 기반 쿼리만으로 비활성 데이터 필터링 가능
+
+## Decision
+
+`deleted_at` 컬럼을 추가하지 않는다.
+비활성 데이터는 `ReservationStatus.CANCELLED`, `HoldStatus.EXPIRED`,
+`PaymentStatus.FAILED` 등 상태 Enum으로 표현한다.
+
+티켓팅 도메인 특성상 예약·HOLD·결제는 상태 전이가 명확하고,
+비활성 여부를 상태값으로 충분히 표현할 수 있으므로 별도의 삭제 플래그가 필요하지 않다.
+
+## Consequences
+
+### Trade-offs
+
+| 항목       | 현재 방식 (상태값 처리)          | Soft Delete 도입 시                              |
+|----------|-------------------------|-----------------------------------------------|
+| 구현 복잡도   | 낮음                      | `deleted_at` 컬럼, `@SQLDelete`, `@Where` 설정 필요 |
+| 데이터 복구   | 불가 (상태 전환은 가능)          | `deleted_at` 초기화로 복구 가능                       |
+| 감사 이력 추적 | 상태 전환 이력으로 부분 추적 가능     | 삭제 시점 이력 추적 가능                                |
+| 쿼리 복잡도   | 상태 조건으로 필터링             | `WHERE deleted_at IS NULL` 조건 항상 필요           |
+| 도메인 표현력  | 상태 Enum으로 비활성 의미 명확히 표현 | 삭제 여부와 상태가 별도로 관리되어 혼재 가능                     |
+
+### Future Path
+
+- 감사 요건 또는 데이터 복구 요건 발생 시 `@SQLDelete` + `@Where` 어노테이션으로 전환 검토
+  → `Entity` 레벨에서 선언하면 `JPA` 쿼리에 자동으로 조건이 추가되어 기존 쿼리 변경 범위를 줄일 수 있다.
+- 이력 추적 요건이 생기면 Soft Delete보다 별도 감사 테이블(`reservation_history`) 도입이
+  더 적합할 수 있으므로 요건 확정 후 방식 결정 필요
+
+## Related Code / Docs
+
+- `reservation/domain/ReservationStatus.java` — PENDING / CONFIRMED /
+  CANCELLED / FAILED 상태 Enum
+- `hold/domain/HoldStatus.java` — ACTIVE / EXPIRED / CONFIRMED 상태 Enum
+- `payment/domain/PaymentStatus.java` — PENDING / SUCCESS / FAILED / REFUNDED 상태
+  Enum
+- `reservation/application/ReservationService.java` — 취소 시 상태 전환 처리
+- 연계 TASK: TASK-058 (CONFIRMED 상태 예약 취소 정책화)


### PR DESCRIPTION
## What

- `docs/architecture/adr/ADR-001-no-kafka.md` 추가 — Kafka 미도입 결정 기록
- `docs/architecture/adr/ADR-002-mock-payment.md` 추가 — Mock 결제 결정 기록
- `docs/architecture/adr/ADR-003-no-outbox.md` 추가 — Outbox Pattern 미적용 결정 기록
- `docs/architecture/adr/ADR-004-no-soft-delete.md` 추가 — Soft Delete 미적용 결정 기록
- `docs/architecture/README.md` — ADR 목차 섹션 추가

## Why

- 프로젝트에는 Kafka 미도입, Mock 결제, Outbox 미적용, Soft Delete 미적용 등
  실무 대비 의도적으로 단순화한 설계 결정이 다수 존재한다
- 이 결정들이 "몰라서 안 한 것"이 아니라 포트폴리오 범위·리소스·트레이드오프를 고려한
  의도적 선택임을 문서로 증명할 필요가 있다
- 코드만으로는 "왜 이 방식인가"를 설명할 수 없으므로 결정 시점의 맥락과 근거를 ADR로 남긴다

## How

- Michael Nygard 스타일 ADR 포맷 적용: Title / Status / Context / Decision / Consequences
- Consequences 내부에 Trade-offs 비교표와 Future Path를 함께 명시
- 각 ADR 하단에 `## Related Code / Docs` 섹션 고정 — 관련 Service, 연계 TASK 번호 명시
- "미도입 이유" 서술이 아닌 "이 시점에 이 선택이 최선이었던 근거" 톤으로 작성
- 미구현 항목(TASK-032, TASK-033)은 "검토 예정"으로 명시하여 문서와 코드 불일치 방지

## Test

- 추가된 테스트: 없음 (문서 작업)
- 수동 테스트
  - 4개 ADR 파일이 `docs/architecture/adr/` 경로에 존재하는지 확인
  - 각 ADR에 Title / Status / Context / Decision / Consequences 섹션 포함 확인
  - `docs/architecture/README.md`에서 각 ADR 파일로 링크 정상 동작 확인

## Notes

> 구현 후 특이사항
- ADR-001: 현재 코드에 Spring Events 미구현 상태이므로 Status를 "전환 예정"이 아닌
  "검토 예정"으로 명시함
- ADR-002: `PaymentGateway` 인터페이스 미분리 상태를 명시하고 Future Path에 분리 방향 기술

closes #84 