### PR TITLE
chore(TASK-057-1): queue:seq:{eventId} 이벤트 종료 시 정리 정책 반영

### DIFF
--- a/src/main/java/com/pil97/ticketing/infra/queue/QueueRedisRepository.java
+++ b/src/main/java/com/pil97/ticketing/infra/queue/QueueRedisRepository.java
@@ -206,6 +206,17 @@ public class QueueRedisRepository implements QueueRepository {
     return seq != null ? seq : 0L;
   }
 
+  /**
+   * 대기열 순번 카운터 key 삭제
+   * DEL queue:seq:{eventId}
+   * 이벤트 종료 시 cleanUpEndedQueue()에서 호출한다.
+   * 삭제하지 않으면 동일 eventId 재오픈 시 이전 카운터 값을 이어받는다.
+   */
+  @Override
+  public void deleteSeq(Long eventId) {
+    redisTemplate.delete(seqKey(eventId));
+  }
+
   // queue:seq:{eventId}
   private String seqKey(Long eventId) {
     return QUEUE_SEQ_KEY_PREFIX + eventId;

--- a/src/main/java/com/pil97/ticketing/queue/application/QueueService.java
+++ b/src/main/java/com/pil97/ticketing/queue/application/QueueService.java
@@ -176,7 +176,7 @@ public class QueueService {
   /**
    * 종료된 이벤트 대기열 정리
    * QueueScheduler에서 호출한다.
-   * queue:event:{eventId} 삭제 + queue:active:events 제거 + 입장 허용 이력 삭제
+   * queue:event:{eventId} 삭제 + queue:active:events 제거 + 입장 허용 이력 삭제 + 순번 카운터 삭제
    *
    * @param eventId 이벤트 ID
    */
@@ -184,6 +184,7 @@ public class QueueService {
     queueRepository.deleteQueue(eventId);
     queueRepository.removeActiveEvent(eventId);
     queueRepository.deleteAdmittedHistory(eventId);
+    queueRepository.deleteSeq(eventId);
     log.info("action=QUEUE_CLEANED_UP eventId={}", eventId);
   }
 

--- a/src/main/java/com/pil97/ticketing/queue/domain/repository/QueueRepository.java
+++ b/src/main/java/com/pil97/ticketing/queue/domain/repository/QueueRepository.java
@@ -161,4 +161,14 @@ public interface QueueRepository {
    * @return 증가된 카운터 값 (고유 score로 사용)
    */
   long nextScore(Long eventId);
+
+  /**
+   * 대기열 순번 카운터 key 삭제
+   * DEL queue:seq:{eventId}
+   * 이벤트 종료 시 cleanUpEndedQueue()에서 호출한다.
+   * 삭제하지 않으면 동일 eventId로 재오픈 시 이전 카운터 값을 이어받는다.
+   *
+   * @param eventId 이벤트 ID
+   */
+  void deleteSeq(Long eventId);
 }

--- a/src/test/java/com/pil97/ticketing/infra/queue/QueueRedisRepositoryTest.java
+++ b/src/test/java/com/pil97/ticketing/infra/queue/QueueRedisRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.pil97.ticketing.infra.queue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * QueueRedisRepository Redis 연동 테스트
+ * 실제 Redis에 key가 생성/삭제되는지 검증한다.
+ * Mockito verify로는 실제 Redis 동작을 보장할 수 없으므로 별도 연동 테스트로 분리한다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+class QueueRedisRepositoryTest {
+
+  @Autowired
+  private QueueRedisRepository queueRedisRepository;
+
+  @Autowired
+  private StringRedisTemplate redisTemplate;
+
+  private static final Long EVENT_ID = 999L;
+
+  @AfterEach
+  void tearDown() {
+    // 테스트 후 잔여 key 정리
+    redisTemplate.delete("queue:seq:" + EVENT_ID);
+  }
+
+  @Test
+  @DisplayName("deleteSeq: queue:seq:{eventId} key가 실제로 삭제된다")
+  void deleteSeq_removesKeyFromRedis() {
+    // given - nextScore() 호출로 queue:seq:{eventId} key 생성
+    queueRedisRepository.nextScore(EVENT_ID);
+    assertThat(redisTemplate.hasKey("queue:seq:" + EVENT_ID)).isTrue();
+
+    // when
+    queueRedisRepository.deleteSeq(EVENT_ID);
+
+    // then
+    assertThat(redisTemplate.hasKey("queue:seq:" + EVENT_ID)).isFalse();
+  }
+}

--- a/src/test/java/com/pil97/ticketing/queue/application/QueueServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/queue/application/QueueServiceTest.java
@@ -195,4 +195,20 @@ class QueueServiceTest {
     assertThat(response.estimatedWaitSeconds()).isGreaterThanOrEqualTo(0L);
     assertThat(response.reEnterType()).isNull();
   }
+
+  @Test
+  @DisplayName("cleanUpEndedQueue: 종료된 이벤트 대기열 정리 시 seq 카운터 key도 함께 삭제한다")
+  void cleanUpEndedQueue_deletesAllKeys() {
+    // given
+    Long eventId = 1L;
+
+    // when
+    queueService.cleanUpEndedQueue(eventId);
+
+    // then
+    verify(queueRepository).deleteQueue(eventId);
+    verify(queueRepository).removeActiveEvent(eventId);
+    verify(queueRepository).deleteAdmittedHistory(eventId);
+    verify(queueRepository).deleteSeq(eventId);
+  }
 }


### PR DESCRIPTION
## What
- `QueueRepository` 인터페이스에 `deleteSeq(Long eventId)` 메서드 추가
- `QueueRedisRepository`에 `deleteSeq()` 구현 (`DEL queue:seq:{eventId}`)
- `QueueService.cleanUpEndedQueue()`에서 `deleteSeq()` 호출 추가
- `QueueServiceTest`에 `cleanUpEndedQueue()` 테스트 추가
- `QueueRedisRepositoryTest` 신규 작성 (Redis 연동 테스트)

## Why
- TASK-057에서 `queue:seq:{eventId}`의 정리 정책을 "이벤트 종료 시 정리"로 문서에 명시했으나 실제 `cleanUpEndedQueue()`에서 해당 key 삭제가 누락된 상태였다.
- 방치 시 동일 eventId로 대기열이 재오픈될 경우 순번이 이전 값을 이어받아 혼란을 야기할 수 있다.

## How
- 기존 `deleteQueue()`, `deleteAdmittedHistory()`와 동일한 `redisTemplate.delete(key)` 패턴으로 구현
- TTL 설정 방식도 대안이나, 이벤트 종료 시점이 코드로 명확히 표현되는 명시적 삭제 방식을 유지

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가된 테스트
  - `QueueServiceTest#cleanUpEndedQueue_deletesAllKeys`: `cleanUpEndedQueue()` 호출 시 `deleteSeq()` 포함 4개 메서드 모두 호출되는지 Mockito verify
  - `QueueRedisRepositoryTest#deleteSeq_removesKeyFromRedis`: `nextScore()`로 key 생성 후 `deleteSeq()` 호출 시 실제 Redis key 미존재 검증

## Notes
- `QueueScheduler`는 수정 불필요 (`cleanUpEndedQueue()` 호출 구조 그대로 유지)

closes #86 