### PR TITLE
docs: 8주차 devlog 추가

### DIFF
--- a/docs/devlog/2026-04-17-w8-wrapup.md
+++ b/docs/devlog/2026-04-17-w8-wrapup.md
@@ -1,0 +1,64 @@
+# 8주차 Wrap-up (2026-04-13 ~ 2026-04-17)
+
+## 이번주 한 일
+
+- TASK-049: 목표 TPS 정의 + 트래픽 시나리오 문서
+  작성 (`docs/performance/traffic-scenario.md`) — 정상 50 TPS / 폭증 500 TPS 수치 기반
+  시나리오 정의
+- TASK-050: 서비스 전체 요약 One Page 작성 (`docs/overview.md`) — 핵심 기술 5가지 선택 이유 + 대안
+  비교 + 전체 요청 흐름 Mermaid 다이어그램 포함
+- TASK-047: 전체 예약 흐름 시나리오 시퀀스 다이어그램 문서화 (`docs/diagrams/reservation-flow.md`) —
+  로그인·대기열·HOLD·예약+결제·결제 전 취소(5-1)와 결제 후 환불(5-2)까지 전체 시나리오 문서화
+- TASK-057: Redis Key Naming 지침 불일치
+  수정 — `lock:seat:{seatId}` → `hold:seat:{showtimeId}:{seatId}` 정정 및 누락 key 3개
+  추가
+- TASK-048: 아키텍처 의사결정 통합 문서(ADR) 작성 — Kafka 미도입 / Mock 결제 / Outbox 미적용 / Soft
+  Delete 미적용 4개 ADR 작성
+- TASK-057-1: `queue:seq:{eventId}` 종료 정리 정책 코드 반영 — `cleanUpEndedQueue()`에서 seq
+  키 명시적 삭제 추가
+
+## 기술 결정
+
+- 트래픽 시나리오 수치 기준 (TASK-049): 인터파크·멜론 수십만 명 규모는 포트폴리오에 과도함. 미드레인지 티켓팅 서비스(500석,
+  2만 명 동시 접속, 경쟁률 40:1)를 기준으로 잡아 "완벽한 수치보다 근거 있는 가정"으로 접근
+- overview.md와 README 역할 분리 (TASK-050): README는 기능 나열 중심, overview.md는 기술 선택
+  이유 + 대안 비교 중심으로 구분. 상세 내용은 각 docs 문서로 링크 위임해 중복 최소화
+- `queue:seq:{eventId}` TTL 대신 명시적 삭제 선택 (TASK-057-1): TTL은 이벤트별 종료 시각을 예측해서 미리
+  설정해야 하는데 이벤트마다 종료 시각이 다를 수 있음. `cleanUpEndedQueue()` 호출 시점에 명시적으로 삭제하는 방식이 의도를
+  코드로 더 명확하게 표현
+- ADR 서술 톤 (TASK-048): "미도입 이유"가 아니라 "이 시점에 이 선택이 최선이었던 근거"로 서술. 각 ADR에 트레이드오프와
+  향후 전환 경로를 명시해 의도적 선택임을 증명
+
+## 트러블슈팅
+
+- Redis Key Naming 지침 불일치 발견 (TASK-057)
+    - TASK-047 문서화 진행 중 지침의 `lock:seat:{seatId}`와 실제 `HoldService`
+      코드의 `hold:seat:{showtimeId}:{seatId}` 불일치 발견
+    - grep으로 실제 코드 교차 검증 후 지침 수정. `QueueRedisRepository`에 구현된 key 3개도 지침 테이블에
+      누락된 것 함께 확인해 추가
+- `queue:seq:{eventId}` 잔존 문제 발견 (TASK-057-1)
+    - `cleanUpEndedQueue()`가 3개 key는 정리하지만 `queue:seq:{eventId}`는 TTL 없이 Redis에
+      계속 잔존하는 것 확인
+    - 동일 eventId로 대기열 재오픈 시 순번이 이전 값을 이어받는 문제 발생 가능. `deleteSeq()` 메서드 추가하고 종료
+      정리 로직에 포함
+
+## 기술 회고
+
+- Q: 좌석 분산락 key에 showtimeId를 포함한 이유는?
+- A: seatId만으로 락을 잡으면 동일 좌석이더라도 다른 공연 회차(showtime)까지 불필요하게 같은 락 범위로 묶인다.
+  showtimeId를 포함해 회차별 좌석 단위로 락 범위를 최소화함으로써 불필요한 락 경합을 줄였다.
+
+- Q: Kafka를 왜 도입하지 않았나요?
+- A: 단일 JVM, 단일 DB 환경에서 브로커를 추가하면 운영 복잡도만 높아지고 실질적인 이점이 없다. 현재는 Spring
+  ApplicationEventPublisher 도입(TASK-032)으로 도메인 간 이벤트를 분리할 계획이고, 트래픽이 증가하거나 서비스가
+  분리되는 시점에 Kafka 전환을 고려한다.
+
+- Q: ADR을 별도 파일로 분리한 이유는?
+- A: 아키텍처 의사결정은 코드 변경과 독립적으로 추적되어야 한다. 하나의 파일에 모아두면 새로운 결정이 추가될 때 기존 내용과 섞여 히스토리
+  파악이 어려워진다. 결정 단위로 파일을 분리하면 각 ADR의 Status(Accepted/Superseded)를 개별로 관리할 수 있다.
+
+## 다음주 계획
+
+- TASK-058로 CONFIRMED 상태 예약 취소 정책을 먼저 정리한 뒤, TASK-046 데이터 정합성 보장 전략과 TASK-052 중복
+  요청 방지 설계로 이어갈 계획이다.
+- 이후 Phase 4(신뢰성 구현) 진입


### PR DESCRIPTION
## What
- `docs/devlog/2026-04-17-w8-wrapup.md` 신규 추가

## Why
TASK-049, TASK-050, TASK-047, TASK-057, TASK-048, TASK-057-1 작업을 마무리한 뒤 8주차 진행 내용을 한 문서로 정리해 작업 흐름과 기술 판단 근거를 기록하기 위해 추가

## How
- 이번 주 한 일 / 기술 결정 / 트러블슈팅 / 기술 회고 / 다음 주 계획 형식으로 작성

## Test
- 파일 경로 및 마크다운 렌더링 확인

closes #88