### PR TITLE
feat(TASK-058): CONFIRMED 상태 예약 직접 취소 차단 및 취소 정책 정리

### DIFF
--- a/src/main/java/com/pil97/ticketing/reservation/application/ReservationService.java
+++ b/src/main/java/com/pil97/ticketing/reservation/application/ReservationService.java
@@ -76,9 +76,10 @@ public class ReservationService {
   }
 
   /**
-   * 예약 취소 처리
-   * - PENDING: 결제 전 취소 - 좌석 HELD -> AVAILABLE 복구
-   * - CONFIRMED: 결제 후 취소 - 좌석 RESERVED -> AVAILABLE 복구
+   * 예약 취소 처리 (PENDING 전용)
+   * - PENDING: 결제 전 취소 - 좌석 HELD -> AVAILABLE 복구, 예약 CANCELLED 처리
+   * - CONFIRMED: 직접 취소 불가 - 환불 API 경로 사용
+   * - HOLD 상태는 별도 변경하지 않는다
    *
    * @param reservationId 취소 대상 예약 ID
    */
@@ -88,10 +89,12 @@ public class ReservationService {
     Reservation reservation = reservationRepository.findById(reservationId)
       .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
 
-    // 2) 취소 가능한 예약인지 검증 (PENDING, CONFIRMED만 허용)
+    // 2) 취소 가능한 예약인지 검증 (PENDING만 허용)
     validateCancellable(reservation);
 
     // 3) 좌석 상태를 AVAILABLE로 복구
+    // HOLD는 ACTIVE/EXPIRED/CONFIRMED만 존재하므로
+    // 사용자 취소를 별도 상태로 표현하지 않고 기존 상태를 유지한다
     reservation.getHold().getShowtimeSeat().markAvailable();
 
     // 4) 예약 상태를 CANCELLED로 변경
@@ -137,13 +140,18 @@ public class ReservationService {
   /**
    * 취소 가능한 예약인지 검증
    * - PENDING: 결제 전 취소 허용
-   * - CONFIRMED: 결제 후 취소 허용
+   * - CONFIRMED: 직접 취소 불가, 환불 API 경로로만 취소 가능
    * - FAILED, CANCELLED: 취소 불가
    */
   private void validateCancellable(Reservation reservation) {
-    if (reservation.getStatus() != ReservationStatus.PENDING
-      && reservation.getStatus() != ReservationStatus.CONFIRMED) {
-      throw new BusinessException(ReservationErrorCode.NOT_CONFIRMED);
+    ReservationStatus status = reservation.getStatus();
+
+    if (status == ReservationStatus.CONFIRMED) {
+      throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND);
+    }
+
+    if (status != ReservationStatus.PENDING) {
+      throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
     }
   }
 }

--- a/src/main/java/com/pil97/ticketing/reservation/domain/Reservation.java
+++ b/src/main/java/com/pil97/ticketing/reservation/domain/Reservation.java
@@ -1,7 +1,9 @@
 package com.pil97.ticketing.reservation.domain;
 
+import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.reservation.error.ReservationErrorCode;
 import com.pil97.ticketing.seat.domain.Seat;
 import com.pil97.ticketing.showtime.domain.Showtime;
 import jakarta.persistence.*;
@@ -38,10 +40,12 @@ public class Reservation {
   private Member member;
 
   /**
-   * ✅ 예약 상태
+   * 예약 상태
+   * - PENDING: 결제 대기 상태
    * - CONFIRMED: 예약 확정 상태
+   * - FAILED: 결제 실패 상태
    * - CANCELLED: 취소 상태
-   * - 예약 생성 시 기본값 CONFIRMED
+   * - 예약 생성 시 기본값은 PENDING
    */
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)
@@ -76,8 +80,11 @@ public class Reservation {
     this.status = ReservationStatus.FAILED;
   }
 
-  // 예약 취소 - CONFIRMED 상태에서만 가능
+  // 예약 취소 - PENDING 상태에서만 가능
   public void cancel() {
+    if (this.status != ReservationStatus.PENDING) {
+      throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+    }
     this.status = ReservationStatus.CANCELLED;
   }
 }

--- a/src/main/java/com/pil97/ticketing/reservation/error/ReservationErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/reservation/error/ReservationErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 /**
  * 예약 도메인 에러코드
  * <p>
- * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: RESERVATION-002)
+ * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: RESERVATION-004)
  * 이 파일은 예약(Reservation) 도메인의 에러를 정의하는 enum입니다.
+ * 기존 RESERVATION-002(NOT_CONFIRMED) 제거
  */
 @Getter
 @RequiredArgsConstructor
@@ -18,8 +19,14 @@ public enum ReservationErrorCode implements ErrorCode {
   // 예약을 찾을 수 없음 - DELETE /reservations/{reservationId} 등
   NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION-001", "Reservation not found"),
 
-  // 취소 불가 상태 - CONFIRMED가 아닌 예약 (이미 CANCELLED된 예약 등)
-  NOT_CONFIRMED(HttpStatus.CONFLICT, "RESERVATION-002", "Reservation is not confirmed");
+  // CONFIRMED 상태 예약 직접 취소 시도 - 환불 경로 사용 안내
+  // CONFIRMED 예약은 POST /payments/{paymentId}/refund 를 통해서만 취소 가능
+  RESERVATION_CANCEL_REQUIRES_REFUND(HttpStatus.CONFLICT, "RESERVATION-003",
+    "Confirmed reservation must be cancelled via refund API"),
+
+  // 취소 불가 상태(FAILED, CANCELLED)에서 취소 시도
+  RESERVATION_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "RESERVATION-004",
+    "Reservation cannot be cancelled in current status");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeat.java
+++ b/src/main/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeat.java
@@ -1,8 +1,10 @@
 package com.pil97.ticketing.showtimeseat.domain;
 
 
+import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.seat.domain.Seat;
 import com.pil97.ticketing.showtime.domain.Showtime;
+import com.pil97.ticketing.showtimeseat.error.ShowtimeSeatErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -43,8 +45,12 @@ public class ShowtimeSeat {
   }
 
   public void markAvailable() {
+    // HELD(결제 전 취소) 또는 RESERVED(환불) 상태에서만 AVAILABLE 전환 허용
+    if (this.status != ShowtimeSeatStatus.HELD
+      && this.status != ShowtimeSeatStatus.RESERVED) {
+      throw new BusinessException(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
+    }
     this.status = ShowtimeSeatStatus.AVAILABLE;
-
   }
 
   public void markReserved() {

--- a/src/main/java/com/pil97/ticketing/showtimeseat/error/ShowtimeSeatErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/showtimeseat/error/ShowtimeSeatErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 /**
  * 회차별 좌석 도메인 에러코드
  * <p>
- * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: SHOWTIME-SEAT-002)
+ * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: SHOWTIME-SEAT-003)
  * 이 파일은 회차별 좌석(ShowtimeSeat) 도메인의 에러를 정의하는 enum입니다.
  */
 @Getter
@@ -19,7 +19,11 @@ public enum ShowtimeSeatErrorCode implements ErrorCode {
   NOT_FOUND(HttpStatus.NOT_FOUND, "SHOWTIME-SEAT-001", "Showtime seat not found"),
 
   // 예약 가능 상태 아님 - 예약 확정은 HELD 상태의 좌석에 대해서만 가능
-  NOT_HELD(HttpStatus.CONFLICT, "SHOWTIME-SEAT-002", "Showtime seat is not held");
+  NOT_HELD(HttpStatus.CONFLICT, "SHOWTIME-SEAT-002", "Showtime seat is not held"),
+
+  // 허용되지 않는 상태 전이 - HELD 또는 RESERVED 상태에서만 AVAILABLE 전환 가능
+  INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "SHOWTIME-SEAT-003",
+    "Invalid seat status transition");
 
   private final HttpStatus status;
   private final String code;

--- a/src/test/java/com/pil97/ticketing/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/reservation/application/ReservationServiceTest.java
@@ -5,18 +5,17 @@ import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.hold.domain.HoldStatus;
 import com.pil97.ticketing.hold.error.HoldErrorCode;
 import com.pil97.ticketing.member.domain.Member;
-import com.pil97.ticketing.reservation.application.ReservationService;
+import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
 import com.pil97.ticketing.reservation.domain.Reservation;
 import com.pil97.ticketing.reservation.domain.ReservationStatus;
 import com.pil97.ticketing.reservation.error.ReservationErrorCode;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
+import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import com.pil97.ticketing.seat.domain.Seat;
 import com.pil97.ticketing.showtime.domain.Showtime;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
 import com.pil97.ticketing.showtimeseat.error.ShowtimeSeatErrorCode;
-import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
-import com.pil97.ticketing.hold.domain.repository.HoldRepository;
-import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -187,61 +186,110 @@ class ReservationServiceTest {
     }
   }
 
-  @Test
-  @DisplayName("CONFIRMED 상태의 예약이면 취소에 성공한다")
-  void cancel_success() {
-    // given
-    Long reservationId = 1L;
+  @Nested
+  @DisplayName("cancel")
+  class Cancel {
 
-    Reservation reservation = mock(Reservation.class);
-    Hold hold = mock(Hold.class);
-    ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
+    @Test
+    @DisplayName("PENDING 상태의 예약이면 취소에 성공한다")
+    void cancel_success() {
+      // given
+      Long reservationId = 1L;
 
-    given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
-    given(reservation.getStatus()).willReturn(ReservationStatus.CONFIRMED);
-    given(reservation.getHold()).willReturn(hold);
-    given(hold.getShowtimeSeat()).willReturn(showtimeSeat);
+      Reservation reservation = mock(Reservation.class);
+      Hold hold = mock(Hold.class);
+      ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
 
-    // when
-    reservationService.cancel(reservationId);
+      given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+      // PENDING 상태만 직접 취소 허용
+      given(reservation.getStatus()).willReturn(ReservationStatus.PENDING);
+      given(reservation.getHold()).willReturn(hold);
+      given(hold.getShowtimeSeat()).willReturn(showtimeSeat);
 
-    // then
-    verify(showtimeSeat).markAvailable();
-    verify(reservation).cancel();
-  }
+      // when
+      reservationService.cancel(reservationId);
 
-  @Test
-  @DisplayName("존재하지 않는 예약이면 예외가 발생한다")
-  void cancel_fail_when_reservation_not_found() {
-    // given
-    Long reservationId = 1L;
-    given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
+      // then
+      verify(showtimeSeat).markAvailable();
+      verify(reservation).cancel();
+      verify(hold, never()).confirm();
+    }
 
-    // when & then
-    assertThatThrownBy(() -> reservationService.cancel(reservationId))
-      .isInstanceOf(BusinessException.class)
-      .extracting("errorCode")
-      .isEqualTo(ReservationErrorCode.NOT_FOUND);
+    @Test
+    @DisplayName("존재하지 않는 예약이면 예외가 발생한다")
+    void cancel_fail_when_reservation_not_found() {
+      // given
+      Long reservationId = 1L;
+      given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
 
-    verify(reservationRepository).findById(reservationId);
-  }
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancel(reservationId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ReservationErrorCode.NOT_FOUND);
 
-  @Test
-  @DisplayName("이미 취소된 예약이면 예외가 발생한다")
-  void cancel_fail_when_reservation_already_cancelled() {
-    // given
-    Long reservationId = 1L;
-    Reservation reservation = mock(Reservation.class);
+      verify(reservationRepository).findById(reservationId);
+    }
 
-    given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
-    given(reservation.getStatus()).willReturn(ReservationStatus.CANCELLED);
+    @Test
+    @DisplayName("CONFIRMED 상태의 예약은 직접 취소 불가 - 환불 API 사용 안내")
+    void cancel_fail_when_reservation_confirmed() {
+      // given
+      Long reservationId = 1L;
+      Reservation reservation = mock(Reservation.class);
 
-    // when & then
-    assertThatThrownBy(() -> reservationService.cancel(reservationId))
-      .isInstanceOf(BusinessException.class)
-      .extracting("errorCode")
-      .isEqualTo(ReservationErrorCode.NOT_CONFIRMED);
+      given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+      given(reservation.getStatus()).willReturn(ReservationStatus.CONFIRMED);
 
-    verify(reservation, never()).cancel();
+      // when & then
+      // CONFIRMED 예약은 POST /payments/{paymentId}/refund 를 통해서만 취소 가능
+      assertThatThrownBy(() -> reservationService.cancel(reservationId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND);
+
+      verify(reservation, never()).cancel();
+      verify(reservation, never()).getHold();
+    }
+
+    @Test
+    @DisplayName("FAILED 상태의 예약은 취소할 수 없다")
+    void cancel_fail_when_reservation_failed() {
+      // given
+      Long reservationId = 1L;
+      Reservation reservation = mock(Reservation.class);
+
+      given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+      given(reservation.getStatus()).willReturn(ReservationStatus.FAILED);
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancel(reservationId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+
+      verify(reservation, never()).cancel();
+      verify(reservation, never()).getHold();
+    }
+
+    @Test
+    @DisplayName("이미 취소된 예약은 취소할 수 없다")
+    void cancel_fail_when_reservation_already_cancelled() {
+      // given
+      Long reservationId = 1L;
+      Reservation reservation = mock(Reservation.class);
+
+      given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+      given(reservation.getStatus()).willReturn(ReservationStatus.CANCELLED);
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.cancel(reservationId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+
+      verify(reservation, never()).cancel();
+      verify(reservation, never()).getHold();
+    }
   }
 }


### PR DESCRIPTION
## What
- `ReservationErrorCode`: `NOT_CONFIRMED` 제거, `RESERVATION_CANCEL_REQUIRES_REFUND` / `RESERVATION_CANCEL_NOT_ALLOWED` 추가
- `Reservation.cancel()`: PENDING 상태 전이 검증 추가
- `ReservationService.cancel()`: CONFIRMED 직접 취소 차단, PENDING 전용으로 범위 축소
- `ShowtimeSeatErrorCode`: `INVALID_STATUS_TRANSITION` 추가
- `ShowtimeSeat.markAvailable()`: RESERVED 상태도 허용하도록 상태 전이 검증 확장
- `ReservationServiceTest`: 취소 정책 테스트 보강

## Why
- 기존 `ReservationService.cancel()`은 PENDING/CONFIRMED 모두 취소를 허용해 Payment는 SUCCESS로 남고 Reservation만 CANCELLED되는 데이터 정합성 문제가 있었다
- CONFIRMED 예약 취소는 반드시 `POST /payments/{paymentId}/refund` 경로로만 처리해야 한다
- 기존 `ShowtimeSeat.markAvailable()`이 HELD 상태만 허용해 환불 흐름(RESERVED → AVAILABLE)에서 예외가 발생하는 버그가 있었다

## How
- `validateCancellable()`을 상태별로 분기해 CONFIRMED는 `RESERVATION_CANCEL_REQUIRES_REFUND`, FAILED/CANCELLED는 `RESERVATION_CANCEL_NOT_ALLOWED` 예외 발생
- `markAvailable()`의 검증 조건을 HELD || RESERVED로 확장하고 `INVALID_STATUS_TRANSITION` 에러코드 적용
- 취소 정책 두 경로를 주석으로 명시

| 상태 | 취소 경로 |
|---|---|
| PENDING | `DELETE /reservations/{id}` |
| CONFIRMED | `POST /payments/{paymentId}/refund` |
| FAILED / CANCELLED | 취소 불가 |

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가된 테스트
  - `ReservationServiceTest`: PENDING 취소 성공 / 예약 없음 / CONFIRMED 직접 취소 차단 / FAILED 취소 불가 / CANCELLED 취소 불가
- 수동 테스트 (Postman)
  - PENDING 예약 취소 → 204 성공 확인
  - CONFIRMED 예약 직접 취소 → 409 + `RESERVATION-003` 차단 확인

## Notes
- 환불 흐름에서 RESERVED → AVAILABLE 전환이 필요해 `ShowtimeSeat.markAvailable()` 상태 전이 검증을 함께 보완
- `PaymentService.refund()`는 변경 없음

closes #90 