### PR TITLE
feat(TASK-046): 상태 전이 가드 추가 및 동시 결제 중복 방지

### DIFF
--- a/src/main/java/com/pil97/ticketing/hold/domain/Hold.java
+++ b/src/main/java/com/pil97/ticketing/hold/domain/Hold.java
@@ -1,6 +1,7 @@
 package com.pil97.ticketing.hold.domain;
 
-
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.hold.error.HoldErrorCode;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import jakarta.persistence.*;
@@ -52,11 +53,37 @@ public class Hold {
     return new Hold(showtimeSeat, member, expiresAt, HoldStatus.ACTIVE);
   }
 
+  /**
+   * HOLD 만료 처리 - 시간 초과 또는 결제 실패/사용자 직접 취소 경로
+   * - ACTIVE 상태에서만 EXPIRED 전환 허용
+   */
   public void expire() {
+    if (this.status != HoldStatus.ACTIVE) {
+      throw new BusinessException(HoldErrorCode.INVALID_STATUS_TRANSITION);
+    }
     this.status = HoldStatus.EXPIRED;
   }
 
+  /**
+   * HOLD 확정 처리 - 결제 성공 경로
+   * - ACTIVE 상태에서만 CONFIRMED 전환 허용
+   */
   public void confirm() {
+    if (this.status != HoldStatus.ACTIVE) {
+      throw new BusinessException(HoldErrorCode.INVALID_STATUS_TRANSITION);
+    }
     this.status = HoldStatus.CONFIRMED;
+  }
+
+  /**
+   * HOLD 환불 처리 - 환불 경로 전용
+   * - CONFIRMED 상태에서만 REFUNDED 전환 허용
+   * - 시간 만료(EXPIRED)와 구분하여 환불로 종료된 선점임을 명시
+   */
+  public void refund() {
+    if (this.status != HoldStatus.CONFIRMED) {
+      throw new BusinessException(HoldErrorCode.INVALID_STATUS_TRANSITION);
+    }
+    this.status = HoldStatus.REFUNDED;
   }
 }

--- a/src/main/java/com/pil97/ticketing/hold/domain/HoldStatus.java
+++ b/src/main/java/com/pil97/ticketing/hold/domain/HoldStatus.java
@@ -3,5 +3,7 @@ package com.pil97.ticketing.hold.domain;
 public enum HoldStatus {
   ACTIVE,
   EXPIRED,
-  CONFIRMED
+  CONFIRMED,
+  // 환불로 종료된 선점 상태 - 시간 만료(EXPIRED)와 구분
+  REFUNDED
 }

--- a/src/main/java/com/pil97/ticketing/hold/error/HoldErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/hold/error/HoldErrorCode.java
@@ -8,21 +8,25 @@ import org.springframework.http.HttpStatus;
 /**
  * 선점 도메인 에러코드
  * <p>
- * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: HOLD-003)
+ * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: HOLD-004)
  * 이 파일은 선점(Hold) 도메인의 에러를 정의하는 enum입니다.
  */
 @Getter
 @RequiredArgsConstructor
 public enum HoldErrorCode implements ErrorCode {
 
-  // HOLD를 찾을 수 없음 - POST /holds/{holdId}/reserve 에서 없는 holdId 접근
+  // HOLD를 찾을 수 없음
   NOT_FOUND(HttpStatus.NOT_FOUND, "HOLD-001", "Hold not found"),
 
-  // 예약 확정 불가 상태 - ACTIVE가 아닌 HOLD (EXPIRED, CONFIRMED 등)
+  // 예약 확정 불가 상태 - ACTIVE가 아닌 HOLD(CONFIRMED 등)
   NOT_ACTIVE(HttpStatus.CONFLICT, "HOLD-002", "Hold is not active"),
 
   // HOLD 만료 - expiresAt 초과 후 예약 확정 요청
-  EXPIRED(HttpStatus.CONFLICT, "HOLD-003", "Hold is expired");
+  EXPIRED(HttpStatus.CONFLICT, "HOLD-003", "Hold is expired"),
+
+  // 허용되지 않는 상태 전이 - ACTIVE 상태에서만 EXPIRED/CONFIRMED 전환 가능
+  INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, "HOLD-004",
+    "Invalid hold status transition");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
+++ b/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
@@ -29,14 +29,8 @@ public class PaymentService {
   /**
    * 결제 처리
    * - idempotency key 누락 시 예외 발생
-   * - 동일 idempotency key로 재요청 시 Redis에서 기존 결과 반환 (DB 처리 없음)
-   * - 예약이 존재하는지 검증한다
-   * - 예약이 PENDING 상태인지 검증한다
-   * - Payment를 PENDING 상태로 저장한다
-   * - forceFailure가 true이면 결제 실패 처리한다 (Redis 저장 안 함 - 재시도 허용)
-   * - 결제 성공 시: Payment SUCCESS, 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED, Redis 저장
-   * - 결제 실패 시: Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE 복구
-   * - 실운영 시 PG 콜백 기반 비동기 처리로 전환 필요
+   * - 동일 idempotency key로 재요청 시 Redis 캐시 반환 (DB 처리 없음)
+   * - 신규 요청은 비관적 락으로 예약을 조회하여 동시 중복 결제 차단
    */
   @Transactional
   public PaymentResponse pay(String idempotencyKey, CreatePaymentRequest request) {
@@ -51,10 +45,10 @@ public class PaymentService {
   /**
    * 환불 처리
    * - paymentId로 결제를 조회한다
-   * - SUCCESS 상태인 경우만 환불 가능 - 그 외 상태는 예외 발생
-   * - 로그인한 사용자가 해당 결제의 소유자인지 검증한다
-   * 소유권 검증은 Service 레이어에서 처리 - "누가 환불할 수 있는가"는 비즈니스 규칙
-   * - Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE 순서로 전환
+   * - 소유권 검증을 상태 검증보다 먼저 수행한다
+   * (상태 검증 먼저 시 타인의 결제 상태 정보가 노출될 수 있음)
+   * - SUCCESS 상태인 경우만 환불 가능
+   * - Payment REFUNDED, 예약 CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE 순서로 전환
    */
   @Transactional
   public PaymentResponse refund(Long paymentId, Member loginMember) {
@@ -63,8 +57,6 @@ public class PaymentService {
       .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
     // 2) 소유권 검증 - 상태 검증보다 먼저 수행
-    //    소유권 검증을 먼저 해야 타인이 paymentId를 추측했을 때 결제 상태 정보가 노출되지 않는다
-    //    (상태 검증 먼저 시 409/403 응답 차이로 상태 유추 가능)
     validateOwnership(payment, loginMember);
 
     // 3) SUCCESS 상태인 경우만 환불 가능
@@ -75,12 +67,12 @@ public class PaymentService {
     // 4) Payment 상태 REFUNDED 전환
     payment.refund();
 
-    // 5) 예약 상태 CANCELLED 전환
+    // 5) 예약 상태 CANCELLED 전환 - 환불 경로 전용 메서드 사용
     Reservation reservation = payment.getReservation();
-    reservation.cancel();
+    reservation.cancelByRefund();
 
-    // 6) HOLD 상태 EXPIRED 전환 - 기존 만료 스케줄러와 동일한 상태값 사용
-    reservation.getHold().expire();
+    // 6) HOLD 상태 REFUNDED 전환 - 시간 만료(EXPIRED)와 구분
+    reservation.getHold().refund();
 
     // 7) 좌석 상태 AVAILABLE 전환
     reservation.getHold().getShowtimeSeat().markAvailable();
@@ -102,10 +94,12 @@ public class PaymentService {
 
   /**
    * 실제 결제 처리 - 최초 요청에서만 실행
-   * idempotency key 중복 확인 후 신규 요청일 때만 호출된다
+   * - 비관적 락으로 예약을 조회하여 동시 중복 결제를 DB 레벨에서 차단
+   * - 락 획득 후 PENDING 상태 재검증으로 선행 요청이 이미 처리된 경우 예외 반환
    */
   private PaymentResponse processPayment(String idempotencyKey, CreatePaymentRequest request) {
-    Reservation reservation = reservationRepository.findById(request.getReservationId())
+    // 비관적 락으로 조회 - 동시 요청 중 하나만 진입, 나머지는 락 해제 후 재검증에서 차단
+    Reservation reservation = reservationRepository.findByIdWithLock(request.getReservationId())
       .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
 
     validatePayable(reservation);
@@ -135,7 +129,7 @@ public class PaymentService {
   /**
    * 결제 가능한 예약인지 검증
    * - PENDING 상태의 예약만 결제 가능
-   * - 이미 처리된 예약(CONFIRMED, FAILED, CANCELLED)은 결제 불가
+   * - 비관적 락 획득 후 재검증하여 선행 요청이 이미 처리한 경우 차단
    */
   private void validatePayable(Reservation reservation) {
     if (reservation.getStatus() != ReservationStatus.PENDING) {

--- a/src/main/java/com/pil97/ticketing/reservation/domain/Reservation.java
+++ b/src/main/java/com/pil97/ticketing/reservation/domain/Reservation.java
@@ -80,9 +80,27 @@ public class Reservation {
     this.status = ReservationStatus.FAILED;
   }
 
-  // 예약 취소 - PENDING 상태에서만 가능
+  /**
+   * 사용자 직접 취소 - PENDING 상태 전용
+   * - CONFIRMED 예약은 환불 API(cancelByRefund) 경로로만 취소 가능
+   */
   public void cancel() {
+    if (this.status == ReservationStatus.CONFIRMED) {
+      throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND);
+    }
     if (this.status != ReservationStatus.PENDING) {
+      throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+    }
+    this.status = ReservationStatus.CANCELLED;
+  }
+
+  /**
+   * 환불 경로 취소 - CONFIRMED 상태 전용
+   * - 사용자 직접 취소(cancel)와 경로를 분리하여 선행 상태 조건을 명확히 한다
+   * - PENDING 등 CONFIRMED 외 상태에서 호출 시 예외 발생
+   */
+  public void cancelByRefund() {
+    if (this.status != ReservationStatus.CONFIRMED) {
       throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
     }
     this.status = ReservationStatus.CANCELLED;

--- a/src/main/java/com/pil97/ticketing/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/pil97/ticketing/reservation/domain/repository/ReservationRepository.java
@@ -1,7 +1,22 @@
 package com.pil97.ticketing.reservation.domain.repository;
 
 import com.pil97.ticketing.reservation.domain.Reservation;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+  /**
+   * 비관적 락을 사용한 예약 조회
+   * - 동시에 동일 예약에 결제 요청이 들어올 경우 SELECT ... FOR UPDATE로 직렬화
+   * - 락 획득 후 PENDING 상태 재검증(validatePayable)으로 중복 결제 차단
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT r FROM Reservation r WHERE r.id = :id")
+  Optional<Reservation> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeat.java
+++ b/src/main/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeat.java
@@ -1,6 +1,5 @@
 package com.pil97.ticketing.showtimeseat.domain;
 
-
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.seat.domain.Seat;
 import com.pil97.ticketing.showtime.domain.Showtime;
@@ -44,8 +43,11 @@ public class ShowtimeSeat {
     this.status = ShowtimeSeatStatus.HELD;
   }
 
+  /**
+   * 좌석 AVAILABLE 복구
+   * - HELD(결제 전 취소) 또는 RESERVED(환불) 상태에서만 AVAILABLE 전환 허용
+   */
   public void markAvailable() {
-    // HELD(결제 전 취소) 또는 RESERVED(환불) 상태에서만 AVAILABLE 전환 허용
     if (this.status != ShowtimeSeatStatus.HELD
       && this.status != ShowtimeSeatStatus.RESERVED) {
       throw new BusinessException(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
@@ -53,7 +55,15 @@ public class ShowtimeSeat {
     this.status = ShowtimeSeatStatus.AVAILABLE;
   }
 
+  /**
+   * 좌석 예약 확정
+   * - HELD 상태에서만 RESERVED 전환 허용
+   * - AVAILABLE 또는 RESERVED 상태에서 호출 시 예외 발생
+   */
   public void markReserved() {
+    if (this.status != ShowtimeSeatStatus.HELD) {
+      throw new BusinessException(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
+    }
     this.status = ShowtimeSeatStatus.RESERVED;
   }
 }

--- a/src/test/java/com/pil97/ticketing/hold/application/HoldConcurrencyTest.java
+++ b/src/test/java/com/pil97/ticketing/hold/application/HoldConcurrencyTest.java
@@ -1,18 +1,33 @@
 package com.pil97.ticketing.hold.application;
 
+import com.pil97.ticketing.event.domain.Event;
+import com.pil97.ticketing.event.domain.EventStatus;
+import com.pil97.ticketing.event.domain.repository.EventRepository;
 import com.pil97.ticketing.hold.api.dto.request.HoldCreateRequest;
-import com.pil97.ticketing.hold.application.HoldService;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
+import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.member.domain.repository.MemberRepository;
 import com.pil97.ticketing.queue.domain.repository.QueueRepository;
+import com.pil97.ticketing.seat.domain.Seat;
+import com.pil97.ticketing.seat.domain.SeatGrade;
+import com.pil97.ticketing.seat.domain.repository.SeatRepository;
+import com.pil97.ticketing.showtime.domain.Showtime;
+import com.pil97.ticketing.showtime.domain.repository.ShowtimeRepository;
+import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
+import com.pil97.ticketing.showtimeseat.domain.repository.ShowtimeSeatRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 테스트 흐름 설명
  * 1. threadCount(10)개 스레드 생성
  * 2. 모든 스레드가 ready 상태가 될 때까지 대기
- * → 스레드가 준비되기도 전에 출발하면 동시성 테스트가 아님
  * 3. start.countDown()으로 10개 스레드 동시 출발
  * 4. 1개만 락 획득 → HOLD 성공 → successCount++
  * 5. 나머지 9개는 HELD 상태 확인 후 예외 → failCount++
@@ -39,43 +53,96 @@ class HoldConcurrencyTest {
   private HoldService holdService;
 
   @Autowired
-  private JdbcTemplate jdbcTemplate;
+  private HoldRepository holdRepository;
+
+  @Autowired
+  private ShowtimeSeatRepository showtimeSeatRepository;
+
+  @Autowired
+  private ShowtimeRepository showtimeRepository;
+
+  @Autowired
+  private SeatRepository seatRepository;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
 
   @Autowired
   private QueueRepository queueRepository;
 
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
   private Long showtimeId;
   private Long seatId;
   private Long memberId;
+  private Long showtimeSeatId;
+  private Long eventId;
 
   @BeforeEach
   void setUp() {
-    // seed 데이터 기준으로 첫 번째 showtime, seat, member를 사용
-    showtimeId = jdbcTemplate.queryForObject(
-      "select id from showtime order by id limit 1", Long.class);
-    seatId = jdbcTemplate.queryForObject(
-      "select id from seat order by id limit 1", Long.class);
-    memberId = jdbcTemplate.queryForObject(
-      "select id from members order by id limit 1", Long.class);
+    LocalDateTime now = LocalDateTime.now();
 
-    // 테스트 전 해당 좌석을 AVAILABLE로 초기화
-    jdbcTemplate.update(
-      "update showtime_seat set status = ? where showtime_id = ? and seat_id = ?",
-      ShowtimeSeatStatus.AVAILABLE.name(),
-      showtimeId,
-      seatId
+    Member member = memberRepository.save(
+      new Member("hold-concurrency-" + System.nanoTime() + "@test.com", "tester", "encoded-pw")
     );
+    memberId = member.getId();
 
-    // 해당 좌석에 걸린 HOLD 전부 삭제
-    jdbcTemplate.update(
-      "delete from holds where showtime_seat_id = ("
-        + "select id from showtime_seat where showtime_id = ? and seat_id = ?)",
-      showtimeId, seatId
-    );
+    Event event = BeanUtils.instantiateClass(Event.class);
+    ReflectionTestUtils.setField(event, "name", "동시성 테스트 이벤트");
+    ReflectionTestUtils.setField(event, "venue", "테스트 공연장");
+    ReflectionTestUtils.setField(event, "status", EventStatus.ON_SALE);
+    ReflectionTestUtils.setField(event, "endTime", now.plusDays(1));
+    ReflectionTestUtils.setField(event, "createdAt", now);
+    ReflectionTestUtils.setField(event, "updatedAt", now);
+    event = eventRepository.save(event);
+    eventId = event.getId();
+
+    Seat seat = BeanUtils.instantiateClass(Seat.class);
+    ReflectionTestUtils.setField(seat, "seatNumber", "B-99");
+    ReflectionTestUtils.setField(seat, "grade", SeatGrade.VIP);
+    ReflectionTestUtils.setField(seat, "rowLabel", "B");
+    ReflectionTestUtils.setField(seat, "seatNo", 99);
+    ReflectionTestUtils.setField(seat, "createdAt", now);
+    ReflectionTestUtils.setField(seat, "updatedAt", now);
+    seat = seatRepository.save(seat);
+    seatId = seat.getId();
+
+    Showtime showtime = BeanUtils.instantiateClass(Showtime.class);
+    ReflectionTestUtils.setField(showtime, "event", event);
+    ReflectionTestUtils.setField(showtime, "showAt", now.plusHours(2));
+    ReflectionTestUtils.setField(showtime, "createdAt", now);
+    ReflectionTestUtils.setField(showtime, "updatedAt", now);
+    showtime = showtimeRepository.save(showtime);
+    showtimeId = showtime.getId();
+
+    ShowtimeSeat showtimeSeat = BeanUtils.instantiateClass(ShowtimeSeat.class);
+    ReflectionTestUtils.setField(showtimeSeat, "showtime", showtime);
+    ReflectionTestUtils.setField(showtimeSeat, "seat", seat);
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.AVAILABLE);
+    ReflectionTestUtils.setField(showtimeSeat, "createdAt", now);
+    ReflectionTestUtils.setField(showtimeSeat, "updatedAt", now);
+    showtimeSeat = showtimeSeatRepository.save(showtimeSeat);
+    showtimeSeatId = showtimeSeat.getId();
 
     // 동시성 테스트에서는 입장 토큰 검증 우회
-    // memberId 1번에 대해 임시 입장 토큰 발급
-    queueRepository.saveAdmissionToken(memberId, "test-token");
+    queueRepository.saveAdmissionToken(memberId, "test-token-" + System.nanoTime());
+  }
+
+  @AfterEach
+  void tearDown() {
+    // 생성된 HOLD 전부 삭제 (동시성 테스트로 여러 건 생성 시도될 수 있음)
+    jdbcTemplate.update(
+      "delete from holds where showtime_seat_id = ?", showtimeSeatId
+    );
+    if (showtimeSeatId != null) showtimeSeatRepository.deleteById(showtimeSeatId);
+    if (showtimeId != null) showtimeRepository.deleteById(showtimeId);
+    if (seatId != null) seatRepository.deleteById(seatId);
+    if (eventId != null) eventRepository.deleteById(eventId);
+    if (memberId != null) memberRepository.deleteById(memberId);
   }
 
   @Test
@@ -84,9 +151,9 @@ class HoldConcurrencyTest {
     // given
     int threadCount = 10;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-    CountDownLatch ready = new CountDownLatch(threadCount); // 모든 스레드 준비 완료 신호
-    CountDownLatch start = new CountDownLatch(1);           // 동시 출발 신호
-    CountDownLatch done = new CountDownLatch(threadCount);  // 모든 스레드 완료 신호
+    CountDownLatch ready = new CountDownLatch(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threadCount);
 
     AtomicInteger successCount = new AtomicInteger(0);
     AtomicInteger failCount = new AtomicInteger(0);
@@ -98,33 +165,33 @@ class HoldConcurrencyTest {
     // when
     for (int i = 0; i < threadCount; i++) {
       executor.submit(() -> {
-        ready.countDown();       // 준비 완료 알림
+        ready.countDown();
         try {
-          start.await();         // 출발 신호 대기
+          start.await();
           holdService.hold(showtimeId, request);
           successCount.incrementAndGet();
         } catch (Exception e) {
           failCount.incrementAndGet();
         } finally {
-          done.countDown();      // 완료 알림
+          done.countDown();
         }
       });
     }
 
-    ready.await();   // 모든 스레드 준비될 때까지 대기
-    start.countDown(); // 동시 출발
-    done.await();    // 모든 스레드 완료될 때까지 대기
+    ready.await();
+    start.countDown();
+    done.await();
     executor.shutdown();
 
     // then
     assertThat(successCount.get()).isEqualTo(1);
     assertThat(failCount.get()).isEqualTo(9);
 
-    // DB에서도 HELD 상태인 showtime_seat이 1개만 존재하는지 확인
+    // DB에서도 HELD 상태인 showtimeSeat가 1개만 존재하는지 확인
     Long heldCount = jdbcTemplate.queryForObject(
-      "select count(*) from showtime_seat where showtime_id = ? and seat_id = ? and status = ?",
+      "select count(*) from showtime_seat where id = ? and status = ?",
       Long.class,
-      showtimeId, seatId, ShowtimeSeatStatus.HELD.name()
+      showtimeSeatId, ShowtimeSeatStatus.HELD.name()
     );
     assertThat(heldCount).isEqualTo(1);
   }

--- a/src/test/java/com/pil97/ticketing/hold/application/HoldExpirationServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/hold/application/HoldExpirationServiceTest.java
@@ -1,29 +1,36 @@
 package com.pil97.ticketing.hold.application;
 
-import com.pil97.ticketing.hold.application.HoldExpirationService;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.hold.domain.HoldStatus;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
+import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.member.domain.repository.MemberRepository;
+import com.pil97.ticketing.seat.domain.Seat;
+import com.pil97.ticketing.seat.domain.SeatGrade;
+import com.pil97.ticketing.seat.domain.repository.SeatRepository;
+import com.pil97.ticketing.showtime.domain.Showtime;
+import com.pil97.ticketing.showtime.domain.repository.ShowtimeRepository;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
-import com.pil97.ticketing.hold.domain.repository.HoldRepository;
 import com.pil97.ticketing.showtimeseat.domain.repository.ShowtimeSeatRepository;
-import jakarta.persistence.EntityManager;
+import com.pil97.ticketing.event.domain.Event;
+import com.pil97.ticketing.event.domain.EventStatus;
+import com.pil97.ticketing.event.domain.repository.EventRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @SpringBootTest(properties = "spring.task.scheduling.enabled=false")
-@Transactional
 class HoldExpirationServiceTest {
 
   @Autowired
@@ -36,63 +43,96 @@ class HoldExpirationServiceTest {
   private ShowtimeSeatRepository showtimeSeatRepository;
 
   @Autowired
-  private JdbcTemplate jdbcTemplate;
+  private ShowtimeRepository showtimeRepository;
 
   @Autowired
-  private EntityManager entityManager;
+  private SeatRepository seatRepository;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  private Long holdId;
+  private Long showtimeSeatId;
+  private Long showtimeId;
+  private Long seatId;
+  private Long eventId;
+  private Long memberId;
+
+  @AfterEach
+  void tearDown() {
+    if (holdId != null) holdRepository.deleteById(holdId);
+    if (showtimeSeatId != null)
+      showtimeSeatRepository.deleteById(showtimeSeatId);
+    if (showtimeId != null) showtimeRepository.deleteById(showtimeId);
+    if (seatId != null) seatRepository.deleteById(seatId);
+    if (eventId != null) eventRepository.deleteById(eventId);
+    if (memberId != null) memberRepository.deleteById(memberId);
+  }
 
   @Test
   @DisplayName("만료된 ACTIVE HOLD를 EXPIRED로 변경하고 좌석을 AVAILABLE로 복구한다")
   void expireExpiredActiveHoldsAndReleaseSeats() {
     // given
-    Long showtimeSeatId = jdbcTemplate.queryForObject(
-      "select id from showtime_seat order by id limit 1",
-      Long.class
-    );
-    assertThat(showtimeSeatId).isNotNull();
-
-    Long memberId = jdbcTemplate.queryForObject(
-      "select id from members order by id limit 1",
-      Long.class
-    );
-    assertThat(memberId).isNotNull();
-
-    // 만료 처리 대상이 되도록 좌석은 HELD, HOLD는 expiresAt < now 상태로 준비
-    jdbcTemplate.update(
-      "update showtime_seat set status = ? where id = ?",
-      ShowtimeSeatStatus.HELD.name(),
-      showtimeSeatId
-    );
-
     LocalDateTime now = LocalDateTime.now();
-    LocalDateTime expiredAt = now.minusMinutes(10);
 
-    jdbcTemplate.update(
-      "insert into holds (showtime_seat_id, member_id, status, expires_at) values (?, ?, ?, ?)",
-      showtimeSeatId,
-      memberId,
-      HoldStatus.ACTIVE.name(),
-      Timestamp.valueOf(expiredAt)
+    Member member = memberRepository.save(
+      new Member("expiration-test-" + System.nanoTime() + "@test.com", "tester", "encoded-pw")
     );
+    memberId = member.getId();
 
-    Long holdId = jdbcTemplate.queryForObject(
-      "select id from holds where showtime_seat_id = ? order by id desc limit 1",
-      Long.class,
-      showtimeSeatId
-    );
-    assertThat(holdId).isNotNull();
+    Event event = BeanUtils.instantiateClass(Event.class);
+    ReflectionTestUtils.setField(event, "name", "만료 테스트 이벤트");
+    ReflectionTestUtils.setField(event, "venue", "테스트 공연장");
+    ReflectionTestUtils.setField(event, "status", EventStatus.ON_SALE);
+    ReflectionTestUtils.setField(event, "endTime", now.plusDays(1));
+    ReflectionTestUtils.setField(event, "createdAt", now);
+    ReflectionTestUtils.setField(event, "updatedAt", now);
+    event = eventRepository.save(event);
+    eventId = event.getId();
+
+    Seat seat = BeanUtils.instantiateClass(Seat.class);
+    ReflectionTestUtils.setField(seat, "seatNumber", "A-99");
+    ReflectionTestUtils.setField(seat, "grade", SeatGrade.VIP);
+    ReflectionTestUtils.setField(seat, "rowLabel", "A");
+    ReflectionTestUtils.setField(seat, "seatNo", 99);
+    ReflectionTestUtils.setField(seat, "createdAt", now);
+    ReflectionTestUtils.setField(seat, "updatedAt", now);
+    seat = seatRepository.save(seat);
+    seatId = seat.getId();
+
+    Showtime showtime = BeanUtils.instantiateClass(Showtime.class);
+    ReflectionTestUtils.setField(showtime, "event", event);
+    ReflectionTestUtils.setField(showtime, "showAt", now.plusHours(2));
+    ReflectionTestUtils.setField(showtime, "createdAt", now);
+    ReflectionTestUtils.setField(showtime, "updatedAt", now);
+    showtime = showtimeRepository.save(showtime);
+    showtimeId = showtime.getId();
+
+    ShowtimeSeat showtimeSeat = BeanUtils.instantiateClass(ShowtimeSeat.class);
+    ReflectionTestUtils.setField(showtimeSeat, "showtime", showtime);
+    ReflectionTestUtils.setField(showtimeSeat, "seat", seat);
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.HELD);
+    ReflectionTestUtils.setField(showtimeSeat, "createdAt", now);
+    ReflectionTestUtils.setField(showtimeSeat, "updatedAt", now);
+    showtimeSeat = showtimeSeatRepository.save(showtimeSeat);
+    showtimeSeatId = showtimeSeat.getId();
+
+    // 만료 대상: ACTIVE 상태 + expiresAt < now
+    Hold hold = Hold.create(showtimeSeat, member, now.minusMinutes(10));
+    hold = holdRepository.save(hold);
+    holdId = hold.getId();
 
     // when
     holdExpirationService.expireHolds(now);
 
-    entityManager.flush();
-    entityManager.clear();
-
     // then
-    Hold hold = holdRepository.findById(holdId).orElseThrow();
-    ShowtimeSeat showtimeSeat = showtimeSeatRepository.findById(showtimeSeatId).orElseThrow();
+    Hold result = holdRepository.findById(holdId).orElseThrow();
+    ShowtimeSeat resultSeat = showtimeSeatRepository.findById(showtimeSeatId).orElseThrow();
 
-    assertThat(hold.getStatus()).isEqualTo(HoldStatus.EXPIRED);
-    assertThat(showtimeSeat.getStatus()).isEqualTo(ShowtimeSeatStatus.AVAILABLE);
+    assertThat(result.getStatus()).isEqualTo(HoldStatus.EXPIRED);
+    assertThat(resultSeat.getStatus()).isEqualTo(ShowtimeSeatStatus.AVAILABLE);
   }
 }

--- a/src/test/java/com/pil97/ticketing/hold/domain/HoldTest.java
+++ b/src/test/java/com/pil97/ticketing/hold/domain/HoldTest.java
@@ -1,0 +1,158 @@
+package com.pil97.ticketing.hold.domain;
+
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.hold.domain.Hold;
+import com.pil97.ticketing.hold.domain.HoldStatus;
+import com.pil97.ticketing.hold.error.HoldErrorCode;
+import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class HoldTest {
+
+  private Hold hold;
+
+  @BeforeEach
+  void setUp() {
+    // 실제 Hold 객체 생성 - ACTIVE 상태로 시작
+    hold = Hold.create(
+      mock(ShowtimeSeat.class),
+      mock(Member.class),
+      LocalDateTime.now().plusMinutes(10)
+    );
+  }
+
+  // ===================== expire() =====================
+
+  @Test
+  @DisplayName("expire: ACTIVE 상태에서 EXPIRED 전환 성공")
+  void expire_active_success() {
+    // when
+    hold.expire();
+
+    // then
+    assertThat(hold.getStatus()).isEqualTo(HoldStatus.EXPIRED);
+  }
+
+  @Test
+  @DisplayName("expire: 이미 EXPIRED 상태에서 재호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void expire_alreadyExpired_throwsException() {
+    // given
+    hold.expire();
+
+    // when & then
+    assertThatThrownBy(() -> hold.expire())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  @Test
+  @DisplayName("expire: CONFIRMED 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void expire_confirmed_throwsException() {
+    // given
+    hold.confirm();
+
+    // when & then
+    assertThatThrownBy(() -> hold.expire())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  // ===================== confirm() =====================
+
+  @Test
+  @DisplayName("confirm: ACTIVE 상태에서 CONFIRMED 전환 성공")
+  void confirm_active_success() {
+    // when
+    hold.confirm();
+
+    // then
+    assertThat(hold.getStatus()).isEqualTo(HoldStatus.CONFIRMED);
+  }
+
+  @Test
+  @DisplayName("confirm: 이미 CONFIRMED 상태에서 재호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void confirm_alreadyConfirmed_throwsException() {
+    // given
+    hold.confirm();
+
+    // when & then
+    assertThatThrownBy(() -> hold.confirm())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  @Test
+  @DisplayName("confirm: EXPIRED 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void confirm_expired_throwsException() {
+    // given
+    hold.expire();
+
+    // when & then
+    assertThatThrownBy(() -> hold.confirm())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  // ===================== refund() =====================
+
+  @Test
+  @DisplayName("refund: CONFIRMED 상태에서 REFUNDED 전환 성공")
+  void refund_confirmed_success() {
+    // given
+    hold.confirm();
+
+    // when
+    hold.refund();
+
+    // then
+    assertThat(hold.getStatus()).isEqualTo(HoldStatus.REFUNDED);
+  }
+
+  @Test
+  @DisplayName("refund: ACTIVE 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void refund_active_throwsException() {
+    // when & then
+    assertThatThrownBy(() -> hold.refund())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  @Test
+  @DisplayName("refund: EXPIRED 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void refund_expired_throwsException() {
+    // given
+    hold.expire();
+
+    // when & then
+    assertThatThrownBy(() -> hold.refund())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(HoldErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+}

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentConcurrencyTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentConcurrencyTest.java
@@ -1,0 +1,230 @@
+package com.pil97.ticketing.payment.application;
+
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.event.domain.Event;
+import com.pil97.ticketing.event.domain.EventStatus;
+import com.pil97.ticketing.event.domain.repository.EventRepository;
+import com.pil97.ticketing.hold.domain.Hold;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
+import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.member.domain.repository.MemberRepository;
+import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
+import com.pil97.ticketing.payment.domain.repository.PaymentRepository;
+import com.pil97.ticketing.payment.error.PaymentErrorCode;
+import com.pil97.ticketing.reservation.domain.Reservation;
+import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
+import com.pil97.ticketing.seat.domain.Seat;
+import com.pil97.ticketing.seat.domain.SeatGrade;
+import com.pil97.ticketing.seat.domain.repository.SeatRepository;
+import com.pil97.ticketing.showtime.domain.Showtime;
+import com.pil97.ticketing.showtime.domain.repository.ShowtimeRepository;
+import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
+import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
+import com.pil97.ticketing.showtimeseat.domain.repository.ShowtimeSeatRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PaymentConcurrencyTest {
+
+  @Autowired
+  private PaymentService paymentService;
+
+  @Autowired
+  private PaymentRepository paymentRepository;
+
+  @Autowired
+  private ReservationRepository reservationRepository;
+
+  @Autowired
+  private HoldRepository holdRepository;
+
+  @Autowired
+  private ShowtimeSeatRepository showtimeSeatRepository;
+
+  @Autowired
+  private ShowtimeRepository showtimeRepository;
+
+  @Autowired
+  private SeatRepository seatRepository;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @MockitoBean
+  private IdempotencyRedisRepository idempotencyRedisRepository;
+
+  private Long paymentId;
+  private Long reservationId;
+  private Long holdId;
+  private Long showtimeSeatId;
+  private Long showtimeId;
+  private Long seatId;
+  private Long eventId;
+  private Long memberId;
+
+  @AfterEach
+  void tearDown() {
+    if (paymentId != null) paymentRepository.deleteById(paymentId);
+    if (reservationId != null) reservationRepository.deleteById(reservationId);
+    if (holdId != null) holdRepository.deleteById(holdId);
+    if (showtimeSeatId != null)
+      showtimeSeatRepository.deleteById(showtimeSeatId);
+    if (showtimeId != null) showtimeRepository.deleteById(showtimeId);
+    if (seatId != null) seatRepository.deleteById(seatId);
+    if (eventId != null) eventRepository.deleteById(eventId);
+    if (memberId != null) memberRepository.deleteById(memberId);
+
+    paymentId = null;
+    reservationId = null;
+    holdId = null;
+    showtimeSeatId = null;
+    showtimeId = null;
+    seatId = null;
+    eventId = null;
+    memberId = null;
+  }
+
+  @Test
+  @DisplayName("동일 reservationId 동시 결제 10건 요청 시 1건만 SUCCESS, 나머지 9건은 PAYMENT_ALREADY_PROCESSED")
+  void pay_sameReservation_concurrently_onlyOneSuccess() throws Exception {
+    // given
+    when(idempotencyRedisRepository.find(anyString())).thenReturn(Optional.empty());
+    doNothing().when(idempotencyRedisRepository).save(anyString(), org.mockito.ArgumentMatchers.any());
+
+    Reservation reservation = createPendingReservation();
+
+    int threadCount = 10;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch readyLatch = new CountDownLatch(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    List<String> results = new CopyOnWriteArrayList<>();
+    List<Throwable> unexpectedErrors = new CopyOnWriteArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      final int index = i;
+      executorService.submit(() -> {
+        try {
+          CreatePaymentRequest request = new CreatePaymentRequest();
+          ReflectionTestUtils.setField(request, "reservationId", reservation.getId());
+          ReflectionTestUtils.setField(request, "amount", 150000);
+          ReflectionTestUtils.setField(request, "forceFailure", false);
+
+          readyLatch.countDown();
+          startLatch.await();
+
+          paymentService.pay("concurrency-key-" + index, request);
+          results.add("SUCCESS");
+        } catch (BusinessException e) {
+          if (e.getErrorCode() == PaymentErrorCode.PAYMENT_ALREADY_PROCESSED) {
+            results.add("PAYMENT_ALREADY_PROCESSED");
+          } else {
+            unexpectedErrors.add(e);
+          }
+        } catch (Throwable t) {
+          unexpectedErrors.add(t);
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    readyLatch.await();
+    startLatch.countDown();
+    doneLatch.await();
+    executorService.shutdown();
+
+    // then
+    long successCount = results.stream().filter("SUCCESS"::equals).count();
+    long alreadyProcessedCount = results.stream().filter("PAYMENT_ALREADY_PROCESSED"::equals).count();
+
+    assertThat(unexpectedErrors).isEmpty();
+    assertThat(successCount).isEqualTo(1);
+    assertThat(alreadyProcessedCount).isEqualTo(9);
+    assertThat(paymentRepository.findByReservationId(reservation.getId())).isPresent();
+    paymentId = paymentRepository.findByReservationId(reservation.getId())
+      .orElseThrow()
+      .getId();
+  }
+
+  private Reservation createPendingReservation() {
+    String uniqueEmail = "pay-test-" + System.nanoTime() + "@test.com";
+    LocalDateTime now = LocalDateTime.now();
+
+    Member member = memberRepository.save(new Member(uniqueEmail, "tester", "encoded-password"));
+    memberId = member.getId();
+
+    Event event = BeanUtils.instantiateClass(Event.class);
+    ReflectionTestUtils.setField(event, "name", "테스트 이벤트");
+    ReflectionTestUtils.setField(event, "venue", "테스트 공연장");
+    ReflectionTestUtils.setField(event, "status", EventStatus.ON_SALE);
+    ReflectionTestUtils.setField(event, "endTime", now.plusDays(1));
+    ReflectionTestUtils.setField(event, "createdAt", now);
+    ReflectionTestUtils.setField(event, "updatedAt", now);
+    event = eventRepository.save(event);
+    eventId = event.getId();
+
+    Seat seat = BeanUtils.instantiateClass(Seat.class);
+    ReflectionTestUtils.setField(seat, "seatNumber", "A-1");
+    ReflectionTestUtils.setField(seat, "grade", SeatGrade.VIP);
+    ReflectionTestUtils.setField(seat, "rowLabel", "A");
+    ReflectionTestUtils.setField(seat, "seatNo", 1);
+    ReflectionTestUtils.setField(seat, "createdAt", now);
+    ReflectionTestUtils.setField(seat, "updatedAt", now);
+    seat = seatRepository.save(seat);
+    seatId = seat.getId();
+
+    Showtime showtime = BeanUtils.instantiateClass(Showtime.class);
+    ReflectionTestUtils.setField(showtime, "event", event);
+    ReflectionTestUtils.setField(showtime, "showAt", now.plusHours(2));
+    ReflectionTestUtils.setField(showtime, "createdAt", now);
+    ReflectionTestUtils.setField(showtime, "updatedAt", now);
+    showtime = showtimeRepository.save(showtime);
+    showtimeId = showtime.getId();
+
+    ShowtimeSeat showtimeSeat = BeanUtils.instantiateClass(ShowtimeSeat.class);
+    ReflectionTestUtils.setField(showtimeSeat, "showtime", showtime);
+    ReflectionTestUtils.setField(showtimeSeat, "seat", seat);
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.HELD);
+    ReflectionTestUtils.setField(showtimeSeat, "createdAt", now);
+    ReflectionTestUtils.setField(showtimeSeat, "updatedAt", now);
+    showtimeSeat = showtimeSeatRepository.save(showtimeSeat);
+    showtimeSeatId = showtimeSeat.getId();
+
+    Hold hold = Hold.create(showtimeSeat, member, now.plusMinutes(5));
+    hold = holdRepository.save(hold);
+    holdId = hold.getId();
+
+    Reservation reservation = Reservation.create(hold, showtime, seat, member);
+    reservation = reservationRepository.save(reservation);
+    reservationId = reservation.getId();
+    return reservation;
+  }
+}

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
@@ -45,7 +45,7 @@ class PaymentServiceTest {
   @InjectMocks
   private PaymentService paymentService;
 
-  // ===================== 기존 케이스 (idempotency key 파라미터 추가) =====================
+  // ===================== 결제 케이스 =====================
 
   @Test
   @DisplayName("pay: 결제 성공 시 Payment SUCCESS, 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다")
@@ -66,7 +66,8 @@ class PaymentServiceTest {
     when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
     when(reservation.getHold()).thenReturn(hold);
 
-    when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+    // 비관적 락 조회 stub
+    when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
 
     Payment savedPayment = mock(Payment.class);
     when(savedPayment.getId()).thenReturn(1L);
@@ -108,7 +109,9 @@ class PaymentServiceTest {
     Reservation reservation = mock(Reservation.class);
     when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
     when(reservation.getHold()).thenReturn(hold);
-    when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+    // 비관적 락 조회 stub
+    when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
 
     Payment savedPayment = mock(Payment.class);
     when(savedPayment.getId()).thenReturn(2L);
@@ -123,7 +126,6 @@ class PaymentServiceTest {
 
     // then
     assertThat(response.status()).isEqualTo("FAIL");
-    assertThat(response.paidAt()).isNull();
 
     verify(savedPayment).fail();
     verify(reservation).fail();
@@ -141,7 +143,7 @@ class PaymentServiceTest {
 
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
     when(request.getReservationId()).thenReturn(999L);
-    when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
+    when(reservationRepository.findByIdWithLock(999L)).thenReturn(Optional.empty());
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when & then
@@ -152,7 +154,6 @@ class PaymentServiceTest {
         assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.NOT_FOUND);
       });
 
-    verify(reservationRepository).findById(999L);
     verifyNoInteractions(paymentRepository);
   }
 
@@ -167,7 +168,7 @@ class PaymentServiceTest {
 
     Reservation reservation = mock(Reservation.class);
     when(reservation.getStatus()).thenReturn(ReservationStatus.CONFIRMED);
-    when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+    when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
     when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
 
     // when & then
@@ -241,50 +242,12 @@ class PaymentServiceTest {
     verifyNoInteractions(idempotencyRedisRepository);
   }
 
-  @Test
-  @DisplayName("pay: forceFailure=true 결제 실패 후 동일 key로 재요청 시 재처리가 허용된다")
-  void pay_forceFailure_thenRetry_allowsReprocessing() {
-    // given
-    String idempotencyKey = "retry-key-001";
-
-    CreatePaymentRequest request = mock(CreatePaymentRequest.class);
-    when(request.getReservationId()).thenReturn(1L);
-    when(request.getAmount()).thenReturn(150000);
-    when(request.isForceFailure()).thenReturn(false);
-
-    ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
-    Hold hold = mock(Hold.class);
-    when(hold.getShowtimeSeat()).thenReturn(showtimeSeat);
-
-    Reservation reservation = mock(Reservation.class);
-    when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
-    when(reservation.getHold()).thenReturn(hold);
-    when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
-
-    Payment savedPayment = mock(Payment.class);
-    when(savedPayment.getId()).thenReturn(1L);
-    when(savedPayment.getStatus()).thenReturn(PaymentStatus.SUCCESS);
-    when(savedPayment.getPaidAt()).thenReturn(null);
-    when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
-
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
-
-    // when
-    PaymentResponse response = paymentService.pay(idempotencyKey, request);
-
-    // then
-    assertThat(response.status()).isEqualTo("SUCCESS");
-    verify(reservationRepository).findById(1L);
-    verify(paymentRepository).save(any(Payment.class));
-  }
-
   // ===================== 환불 케이스 =====================
 
   @Test
-  @DisplayName("refund: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, HOLD EXPIRED, 좌석 AVAILABLE로 전환된다")
+  @DisplayName("refund: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE로 전환된다")
   void refund_success() {
     // given
-    // 로그인 사용자와 예약 소유자가 동일한 경우
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 
@@ -310,8 +273,10 @@ class PaymentServiceTest {
 
     // then
     verify(payment).refund();
-    verify(reservation).cancel();
-    verify(hold).expire();
+    // 환불 경로 전용 cancelByRefund() 호출 확인
+    verify(reservation).cancelByRefund();
+    // 환불로 종료된 HOLD는 REFUNDED 상태로 전환
+    verify(hold).refund();
     verify(showtimeSeat).markAvailable();
   }
 
@@ -319,7 +284,6 @@ class PaymentServiceTest {
   @DisplayName("refund: 타인의 결제 환불 시도 시 BusinessException(REFUND_FORBIDDEN)을 던진다")
   void refund_notOwner_throwsBusinessException() {
     // given
-    // 로그인 사용자(id=2)와 예약 소유자(id=1)가 다른 경우
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(2L);
 
@@ -341,15 +305,13 @@ class PaymentServiceTest {
         assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_FORBIDDEN);
       });
 
-    // 소유권 검증 실패 시 환불 처리 없음
     verify(payment, never()).refund();
   }
 
   @Test
-  @DisplayName("refund: SUCCESS 상태가 아닌 결제 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
+  @DisplayName("refund: SUCCESS 상태가 아닌 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
   void refund_notSuccess_throwsBusinessException() {
     // given
-    // 소유권 검증을 통과시키기 위해 로그인 사용자와 예약 소유자를 동일하게 설정
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 
@@ -376,10 +338,9 @@ class PaymentServiceTest {
   }
 
   @Test
-  @DisplayName("refund: 이미 환불된 결제 재환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
+  @DisplayName("refund: 이미 환불된 결제 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
   void refund_alreadyRefunded_throwsBusinessException() {
     // given
-    // 소유권 검증을 통과시키기 위해 로그인 사용자와 예약 소유자를 동일하게 설정
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 

--- a/src/test/java/com/pil97/ticketing/reservation/domain/ReservationTest.java
+++ b/src/test/java/com/pil97/ticketing/reservation/domain/ReservationTest.java
@@ -1,0 +1,132 @@
+package com.pil97.ticketing.reservation.domain;
+
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.hold.domain.Hold;
+import com.pil97.ticketing.member.domain.Member;
+import com.pil97.ticketing.reservation.domain.Reservation;
+import com.pil97.ticketing.reservation.domain.ReservationStatus;
+import com.pil97.ticketing.reservation.error.ReservationErrorCode;
+import com.pil97.ticketing.seat.domain.Seat;
+import com.pil97.ticketing.showtime.domain.Showtime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class ReservationTest {
+
+  private Reservation reservation;
+
+  @BeforeEach
+  void setUp() {
+    // 실제 Reservation 객체 생성 - PENDING 상태로 시작
+    reservation = Reservation.create(
+      mock(Hold.class),
+      mock(Showtime.class),
+      mock(Seat.class),
+      mock(Member.class)
+    );
+  }
+
+  // ===================== cancel() - 사용자 직접 취소 =====================
+
+  @Test
+  @DisplayName("cancel: PENDING 상태 예약은 취소 성공 후 CANCELLED로 전환된다")
+  void cancel_pending_success() {
+    // when
+    reservation.cancel();
+
+    // then
+    assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+  }
+
+  @Test
+  @DisplayName("cancel: CONFIRMED 상태 예약 직접 취소 시도 시 RESERVATION_CANCEL_REQUIRES_REFUND 예외를 던진다")
+  void cancel_confirmed_throwsRequiresRefund() {
+    // given - CONFIRMED 상태로 전환
+    reservation.confirm();
+
+    // when & then
+    assertThatThrownBy(() -> reservation.cancel())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND);
+      });
+  }
+
+  @Test
+  @DisplayName("cancel: FAILED 상태 예약 취소 시도 시 RESERVATION_CANCEL_NOT_ALLOWED 예외를 던진다")
+  void cancel_failed_throwsNotAllowed() {
+    // given - FAILED 상태로 전환
+    reservation.fail();
+
+    // when & then
+    assertThatThrownBy(() -> reservation.cancel())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+      });
+  }
+
+  @Test
+  @DisplayName("cancel: CANCELLED 상태 예약 재취소 시도 시 RESERVATION_CANCEL_NOT_ALLOWED 예외를 던진다")
+  void cancel_alreadyCancelled_throwsNotAllowed() {
+    // given - 이미 취소된 상태
+    reservation.cancel();
+
+    // when & then
+    assertThatThrownBy(() -> reservation.cancel())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+      });
+  }
+
+  // ===================== cancelByRefund() - 환불 경로 취소 =====================
+
+  @Test
+  @DisplayName("cancelByRefund: CONFIRMED 상태 예약은 환불 취소 성공 후 CANCELLED로 전환된다")
+  void cancelByRefund_confirmed_success() {
+    // given - CONFIRMED 상태로 전환
+    reservation.confirm();
+
+    // when
+    reservation.cancelByRefund();
+
+    // then
+    assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+  }
+
+  @Test
+  @DisplayName("cancelByRefund: PENDING 상태 예약에 환불 취소 시도 시 RESERVATION_CANCEL_NOT_ALLOWED 예외를 던진다")
+  void cancelByRefund_pending_throwsNotAllowed() {
+    // when & then
+    assertThatThrownBy(() -> reservation.cancelByRefund())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+      });
+  }
+
+  @Test
+  @DisplayName("cancelByRefund: FAILED 상태 예약에 환불 취소 시도 시 RESERVATION_CANCEL_NOT_ALLOWED 예외를 던진다")
+  void cancelByRefund_failed_throwsNotAllowed() {
+    // given
+    reservation.fail();
+
+    // when & then
+    assertThatThrownBy(() -> reservation.cancelByRefund())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+      });
+  }
+}

--- a/src/test/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeatTest.java
+++ b/src/test/java/com/pil97/ticketing/showtimeseat/domain/ShowtimeSeatTest.java
@@ -1,0 +1,84 @@
+package com.pil97.ticketing.showtimeseat.domain;
+
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.showtimeseat.error.ShowtimeSeatErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ShowtimeSeatTest {
+
+  private ShowtimeSeat showtimeSeat;
+
+  @BeforeEach
+  void setUp() {
+    showtimeSeat = new ShowtimeSeat();
+  }
+
+  @Test
+  @DisplayName("markAvailable: HELD 상태에서 AVAILABLE 전환 성공")
+  void markAvailable_held_success() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.HELD);
+    showtimeSeat.markAvailable();
+    assertThat(showtimeSeat.getStatus()).isEqualTo(ShowtimeSeatStatus.AVAILABLE);
+  }
+
+  @Test
+  @DisplayName("markAvailable: RESERVED 상태에서 AVAILABLE 전환 성공")
+  void markAvailable_reserved_success() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.RESERVED);
+    showtimeSeat.markAvailable();
+    assertThat(showtimeSeat.getStatus()).isEqualTo(ShowtimeSeatStatus.AVAILABLE);
+  }
+
+  @Test
+  @DisplayName("markAvailable: AVAILABLE 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void markAvailable_available_throwsException() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.AVAILABLE);
+
+    assertThatThrownBy(() -> showtimeSeat.markAvailable())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  @Test
+  @DisplayName("markReserved: HELD 상태에서 RESERVED 전환 성공")
+  void markReserved_held_success() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.HELD);
+    showtimeSeat.markReserved();
+    assertThat(showtimeSeat.getStatus()).isEqualTo(ShowtimeSeatStatus.RESERVED);
+  }
+
+  @Test
+  @DisplayName("markReserved: AVAILABLE 상태에서 호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void markReserved_available_throwsException() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.AVAILABLE);
+
+    assertThatThrownBy(() -> showtimeSeat.markReserved())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+
+  @Test
+  @DisplayName("markReserved: RESERVED 상태에서 재호출 시 INVALID_STATUS_TRANSITION 예외를 던진다")
+  void markReserved_reserved_throwsException() {
+    ReflectionTestUtils.setField(showtimeSeat, "status", ShowtimeSeatStatus.RESERVED);
+
+    assertThatThrownBy(() -> showtimeSeat.markReserved())
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(ShowtimeSeatErrorCode.INVALID_STATUS_TRANSITION);
+      });
+  }
+}


### PR DESCRIPTION
## What
- `HoldStatus`에 `REFUNDED` 추가 (환불로 종료된 선점 상태 명시적 분리)
- `Hold.expire()`, `Hold.confirm()`, `Hold.refund()` 상태 전이 가드 추가
- `HoldErrorCode.INVALID_STATUS_TRANSITION` 추가
- `ShowtimeSeat.markReserved()` 상태 전이 가드 추가
- `Reservation.cancelByRefund()` 추가 (환불 경로 전용 취소 메서드)
- `ReservationRepository.findByIdWithLock()` 추가 (`SELECT ... FOR UPDATE`)
- `PaymentService.refund()` 환불 버그 수정 (`cancel()` → `cancelByRefund()`, `expire()` → `refund()`)
- `PaymentService.processPayment()` 비관적 락 적용
- `ReservationTest`, `HoldTest`, `ShowtimeSeatTest` 상태 전이 가드 단위 테스트 추가
- `PaymentConcurrencyTest` 동시 결제 중복 방지 동시성 테스트 추가
- 기존 통합 테스트 2건(HoldConcurrencyTest, HoldExpirationServiceTest) seed 의존 제거로 테스트 독립성 확보

## Why
- TASK-058에서 `Reservation.cancel()`을 PENDING 전용으로 정책화했으나, `PaymentService.refund()`가 CONFIRMED 예약에 `cancel()`을 호출하고 있어 환불 시 항상 예외가 발생하는 버그가 존재했다
- `Hold`, `ShowtimeSeat`의 상태 전이 메서드에 선행 상태 검증이 없어 잘못된 상태에서 전이가 호출되어도 Entity 레벨에서 차단되지 않았다
- 동시에 동일 `reservationId`로 결제 요청이 들어올 경우 `validatePayable()`의 status 확인만으로는 중복 결제를 막을 수 없다 (TOCTOU 문제)
- 환불로 종료된 HOLD를 `EXPIRED`로 처리하면 "시간 만료"와 "환불 종료" 두 가지 의미가 혼재되어 상태 의미가 불명확하다
- `HoldConcurrencyTest`, `HoldExpirationServiceTest`가 seed 데이터에 의존하여 `PaymentConcurrencyTest` 실행 순서에 따라 불안정하게 실패하는 문제가 있었다

## How
- 환불 경로에서 `Reservation.cancelByRefund()` (CONFIRMED 전용), `Hold.refund()` (CONFIRMED → REFUNDED) 메서드를 분리하여 취소 경로별 선행 상태 조건을 명확히 구분
- `Hold.expire()`, `confirm()`은 ACTIVE 상태에서만, `refund()`는 CONFIRMED 상태에서만 전이 허용하도록 Entity 메서드 내부에서 가드 처리
- `ReservationRepository.findByIdWithLock()`으로 `SELECT ... FOR UPDATE` 적용. 동시 요청 중 하나만 진입하고 나머지는 락 해제 후 `validatePayable()` 재검증에서 `PAYMENT_ALREADY_PROCESSED` 반환
- Redis 분산락 대신 DB 비관적 락을 선택한 이유: 결제는 Redis 장애와 무관하게 DB 레벨에서 정합성이 보장되어야 하기 때문
- `HoldConcurrencyTest`, `HoldExpirationServiceTest`를 테스트 데이터 직접 생성 + tearDown 정리 방식으로 교체하여 실행 순서 독립성 확보

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가된 테스트
  - `ReservationTest`: `cancel()`, `cancelByRefund()` 상태 전이 가드 7개 케이스
  - `HoldTest`: `expire()`, `confirm()`, `refund()` 상태 전이 가드 8개 케이스
  - `ShowtimeSeatTest`: `markAvailable()`, `markReserved()` 상태 전이 가드 6개 케이스
  - `PaymentConcurrencyTest`: 동일 예약 동시 결제 10건 → 1건 SUCCESS, 9건 PAYMENT_ALREADY_PROCESSED
- 수동 테스트 (Postman)
  - 결제 성공 후 환불 → Payment REFUNDED, Reservation CANCELLED, Hold REFUNDED, 좌석 AVAILABLE 확인
  - forceFailure: true 결제 실패 → Payment FAIL, Reservation FAILED, Hold EXPIRED, 좌석 AVAILABLE 확인
  - CONFIRMED 예약 직접 취소 → RESERVATION-003 RESERVATION_CANCEL_REQUIRES_REFUND 반환 확인

## Notes
- 1인 1좌석 제한은 이번 PR 범위 제외. 필요 시 별도 정책으로 분리 예정
- `HoldConcurrencyTest`, `HoldExpirationServiceTest` 테스트 독립성 확보는 새 기능 추가가 아닌 기존 테스트 불안정성 수정으로 이번 브랜치에서 함께 처리

closes #92 