### PR TITLE
feat(TASK-052): Idempotency Key 기반 중복 요청 방지 예약 생성 API로 확장

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ sequenceDiagram
     Server->>DB: Payment SUCCESS, Reservation CONFIRMED, 좌석 RESERVED
     Server-->>Client: 결제 완료
 
-    Client->>Server: 6. DELETE /reservations/{reservationId}
+    Client->>Server: 6. DELETE /reservations/{reservationId} (PENDING only)
     Server->>DB: Reservation CANCELLED, 좌석 AVAILABLE
-    Server-->>Client: 예약 취소 완료
+    Server-->>Client: 결제 전 예약 취소 완료
 
     Client->>Server: 7. POST /payments/{paymentId}/refund
-    Server->>DB: Payment REFUNDED, HOLD EXPIRED
+    Server->>DB: Payment REFUNDED, Reservation CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE
     Server-->>Client: 환불 완료
 ```
 
@@ -75,13 +75,13 @@ sequenceDiagram
 
 ## 핵심 기술 결정
 
-| 결정           | 선택                         | 대안 대비 이유                                                                 |
-|--------------|----------------------------|--------------------------------------------------------------------------|
-| 동시성 제어       | Redis 분산락 (Redisson)       | 비관적 락은 DB 커넥션을 점유해 트래픽 폭증 시 DB 부하 집중. Redis 분산락은 DB 외부에서 락을 관리해 부하 분산 가능 |
-| 대기열          | Redis Sorted Set           | score를 진입 timestamp로 사용해 O(log N)으로 순번 조회/정렬 가능. 별도 MQ 없이 단일 Redis로 처리   |
-| RefreshToken | Rotation 방식                | 토큰 탈취 시 피해자가 재사용을 시도하면 Redis 불일치로 즉시 감지 후 강제 로그아웃                        |
-| 결제 멱등성       | Idempotency Key (Redis 저장) | 네트워크 재시도로 인한 중복 결제를 방지. 동일 키 재요청 시 DB 접근 없이 기존 결과 반환                     |
-| 이벤트 캐시       | Redis Cache (TTL 10분)      | 공연 목록은 변경 빈도가 낮고 조회 빈도가 높음. 캐시로 DB 조회 부하 감소                              |
+| 결정           | 선택                      | 대안 대비 이유                                                                       |
+|--------------|-------------------------|--------------------------------------------------------------------------------|
+| 동시성 제어       | Redis 분산락 (Redisson)    | 비관적 락은 DB 커넥션을 점유해 트래픽 폭증 시 DB 부하 집중. Redis 분산락은 DB 외부에서 락을 관리해 부하 분산 가능       |
+| 대기열          | Redis Sorted Set        | score를 진입 timestamp로 사용해 O(log N)으로 순번 조회/정렬 가능. 별도 MQ 없이 단일 Redis로 처리         |
+| RefreshToken | Rotation 방식             | 토큰 탈취 시 피해자가 재사용을 시도하면 Redis 불일치로 즉시 감지 후 강제 로그아웃                              |
+| 결제 멱등성       | Idempotency Key + Redis | 동일 key 재요청은 기존 결과 반환, 동일 key+다른 payload는 차단, 처리 중 중복 요청은 in-progress lock으로 차단 |
+| 이벤트 캐시       | Redis Cache (TTL 10분)   | 공연 목록은 변경 빈도가 낮고 조회 빈도가 높음. 캐시로 DB 조회 부하 감소                                    |
 
 ---
 
@@ -102,12 +102,13 @@ sequenceDiagram
 ### 예약 플로우
 
 - `POST /showtimes/{showtimeId}/hold` — 좌석 선점 (Redis 분산락 + 5분 유효)
-- `POST /holds/{holdId}/reserve` — 예약 확정
-- `DELETE /reservations/{reservationId}` — 예약 취소 (본인 소유권 검증)
+- `POST /holds/{holdId}/reserve` — 결제 대기 상태 예약 생성(PENDING) (Idempotency-Key 헤더
+  필수)
+- `DELETE /reservations/{reservationId}` — 결제 전 예약 취소 (PENDING 전용)
 
 ### 결제
 
-- `POST /payments` — Mock 결제 (Idempotency Key 멱등성 보장)
+- `POST /payments` — Mock 결제 (Idempotency-Key 헤더 필수, 멱등성 보장)
 - `POST /payments/{paymentId}/refund` — 환불 처리 (본인 소유권 검증)
 
 ### 대기열
@@ -236,18 +237,19 @@ docker compose up -d
 
 에러 코드는 도메인별 Prefix로 구분합니다.
 
-| Prefix              | 도메인               |
-|---------------------|-------------------|
-| `COMMON-xxx`        | 공통 (검증 실패, 서버 에러) |
-| `AUTH-xxx`          | 인증/인가             |
-| `MEMBER-xxx`        | 회원                |
-| `EVENT-xxx`         | 공연                |
-| `SHOWTIME-xxx`      | 회차                |
-| `SHOWTIME-SEAT-xxx` | 회차별 좌석            |
-| `HOLD-xxx`          | 좌석 선점             |
-| `RESERVATION-xxx`   | 예약                |
-| `PAYMENT-xxx`       | 결제                |
-| `QUEUE-xxx`         | 대기열               |
+| Prefix              | 도메인                                |
+|---------------------|------------------------------------|
+| `COMMON-xxx`        | 공통 (검증 실패, 서버 에러)                  |
+| `AUTH-xxx`          | 인증/인가                              |
+| `MEMBER-xxx`        | 회원                                 |
+| `EVENT-xxx`         | 공연                                 |
+| `SHOWTIME-xxx`      | 회차                                 |
+| `SHOWTIME-SEAT-xxx` | 회차별 좌석                             |
+| `HOLD-xxx`          | 좌석 선점                              |
+| `RESERVATION-xxx`   | 예약                                 |
+| `PAYMENT-xxx`       | 결제                                 |
+| `IDEMPOTENCY-xxx`   | 멱등성 (중복 요청 / payload 불일치 / key 누락) |
+| `QUEUE-xxx`         | 대기열                                |
 
 전체 에러 코드는 각 도메인 패키지의 `XxxErrorCode.java`를 참고하세요.
 

--- a/src/main/java/com/pil97/ticketing/common/error/IdempotencyErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/common/error/IdempotencyErrorCode.java
@@ -1,0 +1,31 @@
+package com.pil97.ticketing.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 멱등성 공통 에러코드
+ * - 도메인에 종속되지 않는 인프라 레벨 예외
+ * - 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: IDEMPOTENCY-003)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum IdempotencyErrorCode implements ErrorCode {
+
+  // 동일 key로 동시 요청이 들어와 처리 중인 상태
+  IDEMPOTENCY_IN_PROGRESS(HttpStatus.CONFLICT, "IDEMPOTENCY-001",
+    "The same request is already being processed"),
+
+  // 동일 key로 다른 요청 본문이 전달된 경우
+  IDEMPOTENCY_KEY_PAYLOAD_MISMATCH(HttpStatus.CONFLICT, "IDEMPOTENCY-002",
+    "Idempotency key has already been used with a different request payload"),
+
+  // Idempotency-Key 헤더 누락 시
+  IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "IDEMPOTENCY-003",
+    "Idempotency-Key header is required");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/pil97/ticketing/hold/domain/repository/HoldRepository.java
+++ b/src/main/java/com/pil97/ticketing/hold/domain/repository/HoldRepository.java
@@ -1,20 +1,23 @@
 package com.pil97.ticketing.hold.domain.repository;
 
-
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.hold.domain.HoldStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface HoldRepository extends JpaRepository<Hold, Long> {
+
   List<Hold> findAllByStatusAndExpiresAtBefore(HoldStatus status, LocalDateTime now);
 
   /**
-   * ✅ fetch join을 이용한 만료 HOLD 조회
+   * fetch join을 이용한 만료 HOLD 조회
    * - showtimeSeat를 한 번에 같이 로드해서 N+1 방지
    * - HoldExpirationService에서 루프 돌면서 showtimeSeat에 접근하므로
    * 미리 join해서 가져오지 않으면 Hold 수만큼 추가 쿼리 발생
@@ -24,4 +27,14 @@ public interface HoldRepository extends JpaRepository<Hold, Long> {
     @Param("status") HoldStatus status,
     @Param("now") LocalDateTime now
   );
+
+  /**
+   * 비관적 락을 이용한 HOLD 단건 조회
+   * - 예약 생성 시 동일 HOLD에 대한 동시 요청을 DB 레벨에서 직렬화
+   * - 서로 다른 Idempotency-Key로 동시에 들어온 예약 생성 요청이
+   * 같은 HOLD를 대상으로 할 때 중복 예약 생성을 방지
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select h from Hold h where h.id = :id")
+  Optional<Hold> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyEntry.java
+++ b/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyEntry.java
@@ -1,0 +1,20 @@
+package com.pil97.ticketing.infra.idempotency;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Redis에 저장되는 멱등성 envelope 객체
+ * - fingerprint: 최초 요청 본문의 SHA-256 hash
+ * - responseBody: 직렬화된 응답 JSON 문자열
+ * fingerprint + responseBody를 하나의 JSON으로 직렬화하여 단일 key에 저장한다
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdempotencyEntry {
+
+  private String fingerprint;
+  private String responseBody;
+}

--- a/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyFingerprintUtil.java
+++ b/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyFingerprintUtil.java
@@ -1,0 +1,35 @@
+package com.pil97.ticketing.infra.idempotency;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * 요청 본문의 SHA-256 fingerprint 생성 유틸리티
+ * - 멱등성 검증 시 동일 key + 다른 본문 요청을 구분하기 위해 사용
+ * - 입력값은 요청 본문을 JSON 직렬화한 문자열
+ */
+public class IdempotencyFingerprintUtil {
+
+  private IdempotencyFingerprintUtil() {
+    // 유틸리티 클래스 - 인스턴스 생성 금지
+  }
+
+  /**
+   * 입력 문자열의 SHA-256 hash를 hex 문자열로 반환
+   *
+   * @param input 요청 본문 JSON 문자열
+   * @return SHA-256 hex 문자열
+   */
+  public static String hash(String input) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(bytes);
+    } catch (NoSuchAlgorithmException e) {
+      // SHA-256은 JVM 표준 보장 알고리즘 - 발생하지 않음
+      throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다", e);
+    }
+  }
+}

--- a/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyRedisRepository.java
+++ b/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyRedisRepository.java
@@ -2,7 +2,8 @@ package com.pil97.ticketing.infra.idempotency;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
+import com.pil97.ticketing.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -12,65 +13,135 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * 결제 멱등성 보장을 위한 Redis 저장소
- * key 형식: idempotency:payment:{idempotencyKey}
- * TTL: 24시간
- * 저장 값: PaymentResponse를 JSON으로 직렬화
+ * 멱등성 보장을 위한 범용 Redis 저장소
+ * - fingerprint 비교로 동일 key + 다른 본문 요청 차단
+ * - SETNX 기반 in-progress lock으로 동시 신규 요청 차단
+ * - 결과는 IdempotencyEntry(fingerprint + responseBody) 형태로 저장
  */
 @Slf4j
 @Repository
 @RequiredArgsConstructor
 public class IdempotencyRedisRepository {
 
-  private static final String KEY_PREFIX = "idempotency:payment:";
-  private static final Duration TTL = Duration.ofHours(24);
+  private static final Duration LOCK_TTL = Duration.ofSeconds(10);
 
   private final StringRedisTemplate stringRedisTemplate;
   private final ObjectMapper objectMapper;
 
   /**
-   * idempotency key로 기존 결제 결과를 조회
-   * 결과가 있으면 기존 응답 반환, 없으면 Optional.empty() 반환
+   * 멱등성 처리 전체 흐름
+   * 1. 기존 결과 조회
+   * 2. 결과 있음 → fingerprint 검증 후 캐시 응답 반환
+   * - 일치 → Optional.of(기존 응답) 반환
+   * - 불일치 → IDEMPOTENCY_KEY_PAYLOAD_MISMATCH (409)
+   * 3. 결과 없음 → SETNX lock 선점 시도
+   * - 선점 실패 → IDEMPOTENCY_IN_PROGRESS (409)
+   * - 선점 성공 → Optional.empty() 반환 (신규 처리 진행)
    *
+   * @param prefix         도메인별 key prefix (예: "idempotency:payment")
    * @param idempotencyKey 클라이언트가 전달한 idempotency key
-   * @return 기존 결제 결과 (없으면 Optional.empty())
+   * @param fingerprint    요청 본문의 SHA-256 hash
+   * @param responseType   응답 DTO 타입
+   * @return 기존 처리 결과 (없으면 Optional.empty())
    */
-  public Optional<PaymentResponse> find(String idempotencyKey) {
-    String json = stringRedisTemplate.opsForValue().get(buildKey(idempotencyKey));
-    if (json == null) {
-      return Optional.empty();
+  public <T> Optional<T> find(String prefix, String idempotencyKey,
+                              String fingerprint, Class<T> responseType) {
+    String lockKey = buildLockKey(prefix, idempotencyKey);
+    String resultKey = buildResultKey(prefix, idempotencyKey);
+
+    // 1단계: 기존 결과 먼저 조회
+    String json = stringRedisTemplate.opsForValue().get(resultKey);
+
+    if (json != null) {
+      // 2단계: 결과 있음 - fingerprint 검증 후 캐시 응답 반환
+      try {
+        IdempotencyEntry entry = objectMapper.readValue(json, IdempotencyEntry.class);
+
+        if (!entry.getFingerprint().equals(fingerprint)) {
+          // 동일 key + 다른 본문 - 409 반환
+          throw new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_PAYLOAD_MISMATCH);
+        }
+
+        T response = objectMapper.readValue(entry.getResponseBody(), responseType);
+        return Optional.of(response);
+
+      } catch (JsonProcessingException e) {
+        // 역직렬화 실패 시 손상된 캐시로 간주하고 신규 처리 진행 (결과 key는 TTL 만료까지 남을 수 있음)
+        log.warn("idempotency entry 역직렬화 실패: prefix={}, key={}", prefix, idempotencyKey);
+      }
     }
+
+    // 3단계: 결과 없음 - SETNX lock 선점 시도
+    Boolean acquired = stringRedisTemplate.opsForValue()
+      .setIfAbsent(lockKey, "processing", LOCK_TTL);
+
+    if (Boolean.FALSE.equals(acquired)) {
+      // 다른 요청이 처리 중 - 409 반환
+      throw new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_IN_PROGRESS);
+    }
+
+    // lock 선점 성공 - 신규 처리 진행 (처리 후 save() 호출 필요)
+    return Optional.empty();
+  }
+
+  /**
+   * 처리 성공 결과를 Redis에 저장하고 in-progress lock 해제
+   * - 결과 저장 후 lock 삭제
+   * - 처리 실패 시에는 호출하지 않음 (재시도 허용)
+   *
+   * @param prefix         도메인별 key prefix
+   * @param idempotencyKey 클라이언트가 전달한 idempotency key
+   * @param fingerprint    요청 본문의 SHA-256 hash
+   * @param response       저장할 처리 결과
+   * @param ttl            결과 보관 TTL
+   */
+  public <T> void save(String prefix, String idempotencyKey,
+                       String fingerprint, T response, Duration ttl) {
+    String lockKey = buildLockKey(prefix, idempotencyKey);
+    String resultKey = buildResultKey(prefix, idempotencyKey);
+
     try {
-      return Optional.of(objectMapper.readValue(json, PaymentResponse.class));
+      String responseBody = objectMapper.writeValueAsString(response);
+      IdempotencyEntry entry = new IdempotencyEntry(fingerprint, responseBody);
+      String json = objectMapper.writeValueAsString(entry);
+
+      // 결과 저장 후 lock 해제
+      stringRedisTemplate.opsForValue().set(resultKey, json, ttl);
+      stringRedisTemplate.delete(lockKey);
+
     } catch (JsonProcessingException e) {
-      // 역직렬화 실패 시 캐시 miss로 처리 - 재결제 허용
-      log.warn("idempotency key 역직렬화 실패: key={}", idempotencyKey);
-      return Optional.empty();
+      // 직렬화 실패 시 lock만 해제 - 다음 요청에서 재처리
+      log.warn("idempotency entry 직렬화 실패: prefix={}, key={}", prefix, idempotencyKey);
+      stringRedisTemplate.delete(lockKey);
     }
   }
 
   /**
-   * 결제 성공 결과를 Redis에 저장
-   * 결제 실패 시에는 저장하지 않음 - 재시도 허용
+   * 처리 실패 시 in-progress lock 해제
+   * - 재시도를 허용하기 위해 결과는 저장하지 않고 lock만 해제
    *
+   * @param prefix         도메인별 key prefix
    * @param idempotencyKey 클라이언트가 전달한 idempotency key
-   * @param response       저장할 결제 결과
    */
-  public void save(String idempotencyKey, PaymentResponse response) {
-    try {
-      String json = objectMapper.writeValueAsString(response);
-      stringRedisTemplate.opsForValue().set(buildKey(idempotencyKey), json, TTL);
-    } catch (JsonProcessingException e) {
-      // 직렬화 실패 시 저장 생략 - 다음 요청에서 재처리
-      log.warn("idempotency key 직렬화 실패: key={}", idempotencyKey);
-    }
+  public void releaseLock(String prefix, String idempotencyKey) {
+    stringRedisTemplate.delete(buildLockKey(prefix, idempotencyKey));
   }
 
   /**
-   * Redis key 생성
-   * 형식: idempotency:payment:{idempotencyKey}
+   * 결과 저장 key 생성
+   * 형식: {prefix}:{idempotencyKey}
+   * 예: idempotency:payment:uuid-1234
    */
-  private String buildKey(String idempotencyKey) {
-    return KEY_PREFIX + idempotencyKey;
+  private String buildResultKey(String prefix, String idempotencyKey) {
+    return prefix + ":" + idempotencyKey;
+  }
+
+  /**
+   * in-progress lock key 생성
+   * 형식: {prefix}:lock:{idempotencyKey}
+   * 예: idempotency:payment:lock:uuid-1234
+   */
+  private String buildLockKey(String prefix, String idempotencyKey) {
+    return prefix + ":lock:" + idempotencyKey;
   }
 }

--- a/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyResult.java
+++ b/src/main/java/com/pil97/ticketing/infra/idempotency/IdempotencyResult.java
@@ -1,0 +1,27 @@
+package com.pil97.ticketing.infra.idempotency;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 멱등성 처리 결과 래퍼
+ * - replayed: true이면 Redis 캐시에서 반환된 재요청 응답
+ * - replayed: false이면 신규 처리된 응답
+ * - 컨트롤러에서 신규(201) / 재요청(200) 상태코드 분기에 사용
+ */
+@Getter
+@RequiredArgsConstructor
+public class IdempotencyResult<T> {
+
+  private final T response;
+  // true: 캐시 응답 (재요청), false: 신규 처리
+  private final boolean replayed;
+
+  public static <T> IdempotencyResult<T> ofNew(T response) {
+    return new IdempotencyResult<>(response, false);
+  }
+
+  public static <T> IdempotencyResult<T> ofReplayed(T response) {
+    return new IdempotencyResult<>(response, true);
+  }
+}

--- a/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
+++ b/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
@@ -1,6 +1,7 @@
 package com.pil97.ticketing.payment.api;
 
 import com.pil97.ticketing.common.response.ApiResponse;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
@@ -24,20 +25,28 @@ public class PaymentController {
    * POST /payments
    * - Mock 결제를 처리한다.
    * - 결제 성공 시 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다.
-   * - 결제 실패 시 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구된다.
-   * - forceFailure: true이면 강제 실패 처리 (Mock 결제 실패 시나리오 재현용)
-   * - Idempotency-Key 헤더 누락 시 400 에러 반환 (PAYMENT-004)
+   * - 결제 실패 시 예약 FAILED, 좌석 AVAILABLE로 복구된다.
+   * - forceFailure: true이면 강제 실패 처리 (실패 시나리오 재현용)
+   * <p>
+   * 멱등성 정책:
+   * - Idempotency-Key 헤더 필수
+   * - 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200)
+   * - 동일 key + 다른 본문 재요청 시 409 반환
+   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리, 나머지 409 반환
+   * - Idempotency-Key 헤더 누락 시 400 에러 (IDEMPOTENCY-003)
    */
   @PostMapping("/payments")
   public ResponseEntity<ApiResponse<PaymentResponse>> pay(
     @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
     @RequestBody @Valid CreatePaymentRequest request) {
 
-    PaymentResponse response = paymentService.pay(idempotencyKey, request);
+    IdempotencyResult<PaymentResponse> result = paymentService.pay(idempotencyKey, request);
+
+    HttpStatus status = result.isReplayed() ? HttpStatus.OK : HttpStatus.CREATED;
 
     return ResponseEntity
-      .status(HttpStatus.CREATED)
-      .body(ApiResponse.success(response));
+      .status(status)
+      .body(ApiResponse.success(result.getResponse()));
   }
 
   /**
@@ -45,7 +54,7 @@ public class PaymentController {
    * - 결제 성공(SUCCESS) 상태인 결제에 대해 환불을 처리한다.
    * - 본인 소유 결제가 아닌 경우 403 반환 (PAYMENT-006)
    * - SUCCESS 상태가 아닌 결제 환불 시도 시 409 반환 (PAYMENT-005)
-   * - Controller는 요청/응답 변환만 담당 - 소유권 검증은 Service에서 처리
+   * - Controller는 요청/응답 변환만 담당 - 소유권/상태 검증은 Service에서 처리
    */
   @PostMapping("/payments/{paymentId}/refund")
   public ResponseEntity<ApiResponse<PaymentResponse>> refund(
@@ -53,7 +62,6 @@ public class PaymentController {
     @AuthenticationPrincipal Member loginMember) {
 
     PaymentResponse response = paymentService.refund(paymentId, loginMember);
-
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
+++ b/src/main/java/com/pil97/ticketing/payment/application/PaymentService.java
@@ -1,7 +1,12 @@
 package com.pil97.ticketing.payment.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
 import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.infra.idempotency.IdempotencyFingerprintUtil;
 import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
@@ -14,32 +19,51 @@ import com.pil97.ticketing.reservation.domain.ReservationStatus;
 import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import com.pil97.ticketing.reservation.error.ReservationErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PaymentService {
 
+  // 결제 멱등성 key prefix
+  private static final String IDEMPOTENCY_PREFIX = "idempotency:payment";
+  // 결제 멱등성 결과 보관 TTL
+  private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(24);
+
   private final PaymentRepository paymentRepository;
   private final ReservationRepository reservationRepository;
   private final IdempotencyRedisRepository idempotencyRedisRepository;
+  private final ObjectMapper objectMapper;
 
   /**
    * 결제 처리
    * - idempotency key 누락 시 예외 발생
-   * - 동일 idempotency key로 재요청 시 Redis 캐시 반환 (DB 처리 없음)
-   * - 신규 요청은 비관적 락으로 예약을 조회하여 동시 중복 결제 차단
+   * - 동일 key + 동일 본문 재요청 시 Redis 캐시 반환 (DB 처리 없음)
+   * - 동일 key + 다른 본문 재요청 시 409 반환
+   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리
    */
   @Transactional
-  public PaymentResponse pay(String idempotencyKey, CreatePaymentRequest request) {
+  public IdempotencyResult<PaymentResponse> pay(String idempotencyKey, CreatePaymentRequest request) {
     if (idempotencyKey == null || idempotencyKey.isBlank()) {
-      throw new BusinessException(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING);
+      throw new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING);
     }
 
-    return idempotencyRedisRepository.find(idempotencyKey)
-      .orElseGet(() -> processPayment(idempotencyKey, request));
+    String fingerprint = computeFingerprint(request);
+
+    return idempotencyRedisRepository
+      .find(IDEMPOTENCY_PREFIX, idempotencyKey, fingerprint, PaymentResponse.class)
+      .map(IdempotencyResult::ofReplayed)
+      .orElseGet(() -> IdempotencyResult.ofNew(
+        processPayment(idempotencyKey, fingerprint, request)
+      ));
   }
 
   /**
@@ -48,33 +72,25 @@ public class PaymentService {
    * - 소유권 검증을 상태 검증보다 먼저 수행한다
    * (상태 검증 먼저 시 타인의 결제 상태 정보가 노출될 수 있음)
    * - SUCCESS 상태인 경우만 환불 가능
-   * - Payment REFUNDED, 예약 CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE 순서로 전환
+   * - Payment REFUNDED, 예약 CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE 전환
    */
   @Transactional
   public PaymentResponse refund(Long paymentId, Member loginMember) {
-    // 1) 결제 존재 여부 확인
     Payment payment = paymentRepository.findById(paymentId)
       .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-    // 2) 소유권 검증 - 상태 검증보다 먼저 수행
+    // 소유권 검증 - 상태 검증보다 먼저 수행
     validateOwnership(payment, loginMember);
 
-    // 3) SUCCESS 상태인 경우만 환불 가능
     if (payment.getStatus() != PaymentStatus.SUCCESS) {
       throw new BusinessException(PaymentErrorCode.REFUND_NOT_ALLOWED);
     }
 
-    // 4) Payment 상태 REFUNDED 전환
     payment.refund();
 
-    // 5) 예약 상태 CANCELLED 전환 - 환불 경로 전용 메서드 사용
     Reservation reservation = payment.getReservation();
     reservation.cancelByRefund();
-
-    // 6) HOLD 상태 REFUNDED 전환 - 시간 만료(EXPIRED)와 구분
     reservation.getHold().refund();
-
-    // 7) 좌석 상태 AVAILABLE 전환
     reservation.getHold().getShowtimeSeat().markAvailable();
 
     return PaymentResponse.of(payment);
@@ -95,35 +111,82 @@ public class PaymentService {
   /**
    * 실제 결제 처리 - 최초 요청에서만 실행
    * - 비관적 락으로 예약을 조회하여 동시 중복 결제를 DB 레벨에서 차단
-   * - 락 획득 후 PENDING 상태 재검증으로 선행 요청이 이미 처리된 경우 예외 반환
+   * - 처리 성공 시 트랜잭션 커밋 후 Redis에 결과 저장 (커밋 전 저장 시 DB/Redis 불일치 위험)
+   * - 처리 실패 또는 예외 발생 시 lock 해제하여 재시도 허용
+   * - forceFailure 경로: 결제 실패 응답 반환 후 캐시 저장 안 함 - 동일 key 재시도 시 재처리
    */
-  private PaymentResponse processPayment(String idempotencyKey, CreatePaymentRequest request) {
-    // 비관적 락으로 조회 - 동시 요청 중 하나만 진입, 나머지는 락 해제 후 재검증에서 차단
-    Reservation reservation = reservationRepository.findByIdWithLock(request.getReservationId())
-      .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
+  private PaymentResponse processPayment(String idempotencyKey, String fingerprint,
+                                         CreatePaymentRequest request) {
+    boolean success = false;
+    try {
+      Reservation reservation = reservationRepository.findByIdWithLock(request.getReservationId())
+        .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
 
-    validatePayable(reservation);
+      validatePayable(reservation);
 
-    Payment payment = Payment.create(reservation, request.getAmount());
-    Payment savedPayment = paymentRepository.save(payment);
+      Payment payment = Payment.create(reservation, request.getAmount());
+      Payment savedPayment = paymentRepository.save(payment);
 
-    if (request.isForceFailure()) {
-      savedPayment.fail();
-      reservation.fail();
-      reservation.getHold().expire();
-      reservation.getHold().getShowtimeSeat().markAvailable();
-      return PaymentResponse.of(savedPayment);
+      if (request.isForceFailure()) {
+        savedPayment.fail();
+        reservation.fail();
+        reservation.getHold().expire();
+        reservation.getHold().getShowtimeSeat().markAvailable();
+        // 결제 실패 - lock 해제하여 재시도 허용 (캐시 저장 안 함)
+        return PaymentResponse.of(savedPayment);
+      }
+
+      savedPayment.success();
+      reservation.confirm();
+      reservation.getHold().getShowtimeSeat().markReserved();
+      reservation.getHold().confirm();
+
+      PaymentResponse response = PaymentResponse.of(savedPayment);
+
+      // 트랜잭션 커밋 후 Redis 저장
+      // - 커밋 전 저장 시 롤백되면 DB에는 실패, Redis에는 성공 응답이 남는 불일치 발생
+      // - afterCommit 콜백에서 실행하여 DB 커밋 성공이 보장된 후 저장
+      registerAfterCommit(idempotencyKey, fingerprint, response);
+
+      success = true;
+      return response;
+
+    } finally {
+      // 성공 시에는 afterCommit에서 lock 해제, 실패 시에는 즉시 해제
+      if (!success) {
+        idempotencyRedisRepository.releaseLock(IDEMPOTENCY_PREFIX, idempotencyKey);
+      }
+    }
+  }
+
+  /**
+   * 트랜잭션 커밋 후 Redis 결과 저장 및 lock 해제 등록
+   * - afterCommit: 커밋 성공 시에만 실행
+   * - afterCompletion: 롤백 포함 모든 완료 시 실행 - lock 해제 보장
+   */
+  private void registerAfterCommit(String idempotencyKey, String fingerprint,
+                                   PaymentResponse response) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      throw new IllegalStateException("Transaction synchronization is not active");
     }
 
-    savedPayment.success();
-    reservation.confirm();
-    reservation.getHold().getShowtimeSeat().markReserved();
-    reservation.getHold().confirm();
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 
-    PaymentResponse response = PaymentResponse.of(savedPayment);
-    idempotencyRedisRepository.save(idempotencyKey, response);
+      @Override
+      public void afterCommit() {
+        // DB 커밋 성공 후 Redis에 결과 저장 및 lock 해제
+        idempotencyRedisRepository.save(
+          IDEMPOTENCY_PREFIX, idempotencyKey, fingerprint, response, IDEMPOTENCY_TTL);
+      }
 
-    return response;
+      @Override
+      public void afterCompletion(int status) {
+        // 롤백 등 커밋 외 완료 시 lock만 해제 (afterCommit이 실행된 경우 save()에서 이미 해제됨)
+        if (status != STATUS_COMMITTED) {
+          idempotencyRedisRepository.releaseLock(IDEMPOTENCY_PREFIX, idempotencyKey);
+        }
+      }
+    });
   }
 
   /**
@@ -134,6 +197,19 @@ public class PaymentService {
   private void validatePayable(Reservation reservation) {
     if (reservation.getStatus() != ReservationStatus.PENDING) {
       throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+    }
+  }
+
+  /**
+   * 요청 본문의 SHA-256 fingerprint 계산
+   * - 직렬화 실패 시 빈 문자열 hash로 대체 (처리는 계속 진행)
+   */
+  private String computeFingerprint(CreatePaymentRequest request) {
+    try {
+      return IdempotencyFingerprintUtil.hash(objectMapper.writeValueAsString(request));
+    } catch (JsonProcessingException e) {
+      log.warn("fingerprint 계산 실패 - 빈 문자열 hash로 대체");
+      return IdempotencyFingerprintUtil.hash("");
     }
   }
 }

--- a/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/payment/error/PaymentErrorCode.java
@@ -9,6 +9,7 @@ import com.pil97.ticketing.common.error.ErrorCode;
 /**
  * 결제 도메인 에러코드
  * 새 항목 추가 시 다음 순번으로 추가할 것 (현재 마지막: PAYMENT-006)
+ * PAYMENT-004: IDEMPOTENCY_KEY_MISSING - TASK-052에서 IdempotencyErrorCode(IDEMPOTENCY-003)으로 이동
  * 이 파일은 결제 도메인에서 발생하는 비즈니스 예외를 정의하는 enum입니다.
  */
 @Getter
@@ -23,9 +24,6 @@ public enum PaymentErrorCode implements ErrorCode {
 
   // 결제 처리 중 실패 (forceFailure 또는 내부 오류)
   PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT-003", "Payment failed"),
-
-  // Idempotency-Key 헤더 누락 시
-  IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "PAYMENT-004", "Idempotency-Key header is required"),
 
   // SUCCESS 상태가 아닌 결제에 환불 시도 시
   REFUND_NOT_ALLOWED(HttpStatus.CONFLICT, "PAYMENT-005", "Refund is only allowed for successful payments"),

--- a/src/main/java/com/pil97/ticketing/reservation/api/ReservationController.java
+++ b/src/main/java/com/pil97/ticketing/reservation/api/ReservationController.java
@@ -1,16 +1,14 @@
 package com.pil97.ticketing.reservation.api;
 
 import com.pil97.ticketing.common.response.ApiResponse;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
 import com.pil97.ticketing.reservation.application.ReservationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "6. Reservation", description = "예약 API - 예약 확정 / 예약 취소")
 @RestController
@@ -23,27 +21,31 @@ public class ReservationController {
    * POST /holds/{holdId}/reserve
    * <p>
    * 이 API의 목적:
-   * - 유효한 HOLD를 최종 예약 확정(RESERVE)한다.
-   * - 성공 시 좌석 상태는 RESERVED로 변경되고, HOLD 상태는 CONFIRMED로 변경된다.
+   * - 유효한 HOLD를 기반으로 결제 대기 상태의 예약(PENDING)을 생성한다.
+   * - 좌석 상태와 HOLD 상태 전이는 결제 완료(PaymentService) 시점에 처리된다.
    * <p>
    * 상태코드 정책:
    * - 예약 확정 성공 시 201 Created
    * <p>
-   * 응답 정책:
-   * - 표준 응답 포맷(ApiResponse)로 감싸서 반환
+   * 멱등성 정책:
+   * - Idempotency-Key 헤더 필수
+   * - 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200)
+   * - 동일 key + 다른 본문 재요청 시 409 반환
+   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리, 나머지 409 반환
    */
   @PostMapping("/holds/{holdId}/reserve")
-  public ResponseEntity<ApiResponse<ReservationResponse>> reserve(@PathVariable Long holdId) {
+  public ResponseEntity<ApiResponse<ReservationResponse>> reserve(
+    @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+    @PathVariable Long holdId) {
 
-    // 서비스 호출: 예약 확정 처리
-    ReservationResponse response = reservationService.reserve(holdId);
+    IdempotencyResult<ReservationResponse> result = reservationService.reserve(idempotencyKey, holdId);
 
-    // 201 Created + 표준 응답
+    HttpStatus status = result.isReplayed() ? HttpStatus.OK : HttpStatus.CREATED;
+
     return ResponseEntity
-      .status(HttpStatus.CREATED)
-      .body(ApiResponse.success(response));
+      .status(status)
+      .body(ApiResponse.success(result.getResponse()));
   }
-
 
   /**
    * DELETE /reservations/{reservationId}

--- a/src/main/java/com/pil97/ticketing/reservation/application/ReservationService.java
+++ b/src/main/java/com/pil97/ticketing/reservation/application/ReservationService.java
@@ -1,78 +1,79 @@
 package com.pil97.ticketing.reservation.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.hold.domain.HoldStatus;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
 import com.pil97.ticketing.hold.error.HoldErrorCode;
+import com.pil97.ticketing.infra.idempotency.IdempotencyFingerprintUtil;
+import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
+import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
 import com.pil97.ticketing.reservation.domain.Reservation;
 import com.pil97.ticketing.reservation.domain.ReservationStatus;
+import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import com.pil97.ticketing.reservation.error.ReservationErrorCode;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
 import com.pil97.ticketing.showtimeseat.error.ShowtimeSeatErrorCode;
-import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
-import com.pil97.ticketing.hold.domain.repository.HoldRepository;
-import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReservationService {
 
+  // 예약 멱등성 key prefix
+  private static final String IDEMPOTENCY_PREFIX = "idempotency:reservation";
+  // 예약 멱등성 결과 보관 TTL
+  private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(24);
+
   private final HoldRepository holdRepository;
   private final ReservationRepository reservationRepository;
+  private final IdempotencyRedisRepository idempotencyRedisRepository;
+  private final ObjectMapper objectMapper;
 
   /**
    * 예약 생성 처리 (결제 대기 상태)
-   * - holdId로 HOLD를 조회한다
-   * - HOLD가 존재하는지 검증한다
-   * - HOLD가 ACTIVE 상태인지 검증한다
-   * - HOLD가 만료되지 않았는지 검증한다
-   * - 연결된 좌석 상태가 HELD인지 검증한다
-   * - 예약을 PENDING 상태로 저장한다
-   * - 좌석/HOLD 상태 변경은 결제 완료(PaymentService) 시점에 처리한다
+   * - idempotency key 누락 시 예외 발생
+   * - 동일 key + 동일 본문 재요청 시 Redis 캐시 반환 (DB 처리 없음)
+   * - 동일 key + 다른 본문 재요청 시 409 반환
+   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리
+   * - 예약 성공 후 좌석/HOLD 상태 변경은 결제 완료(PaymentService) 시점에 처리
    *
-   * @param holdId 예약 대상 HOLD ID
+   * @param idempotencyKey 클라이언트가 전달한 idempotency key
+   * @param holdId         예약 대상 HOLD ID
    * @return 예약 생성 결과 응답
    */
   @Transactional
-  public ReservationResponse reserve(Long holdId) {
-    // 1) HOLD 존재 여부 확인
-    Hold hold = holdRepository.findById(holdId)
-      .orElseThrow(() -> new BusinessException(HoldErrorCode.NOT_FOUND));
+  public IdempotencyResult<ReservationResponse> reserve(
+    String idempotencyKey,
+    Long holdId
+  ) {
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      throw new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING);
+    }
 
-    // 2) 예약 가능한 HOLD인지 검증
-    validateReservableHold(hold);
+    String fingerprint = computeFingerprint(holdId);
 
-    // 3) 연결된 회차별 좌석 조회
-    ShowtimeSeat showtimeSeat = hold.getShowtimeSeat();
-
-    // 4) 예약 PENDING 상태로 생성 및 저장
-    // 좌석/HOLD 상태 변경은 결제 완료 시점(PaymentService)에 처리
-    Reservation reservation = Reservation.create(
-      hold,
-      showtimeSeat.getShowtime(),
-      showtimeSeat.getSeat(),
-      hold.getMember()
-    );
-
-    Reservation savedReservation = reservationRepository.save(reservation);
-
-    // 5) 응답 반환 - 좌석/HOLD 상태는 아직 변경되지 않음
-    return new ReservationResponse(
-      savedReservation.getId(),
-      hold.getId(),
-      showtimeSeat.getShowtime().getId(),
-      showtimeSeat.getSeat().getId(),
-      hold.getMember().getId(),
-      showtimeSeat.getStatus().name(),
-      hold.getStatus().name()
-    );
+    return idempotencyRedisRepository
+      .find(IDEMPOTENCY_PREFIX, idempotencyKey, fingerprint, ReservationResponse.class)
+      .map(IdempotencyResult::ofReplayed)
+      .orElseGet(() -> IdempotencyResult.ofNew(
+        processReserve(idempotencyKey, fingerprint, holdId)
+      ));
   }
 
   /**
@@ -85,20 +86,100 @@ public class ReservationService {
    */
   @Transactional
   public void cancel(Long reservationId) {
-    // 1) 예약 존재 여부 확인
     Reservation reservation = reservationRepository.findById(reservationId)
       .orElseThrow(() -> new BusinessException(ReservationErrorCode.NOT_FOUND));
 
-    // 2) 취소 가능한 예약인지 검증 (PENDING만 허용)
     validateCancellable(reservation);
 
-    // 3) 좌석 상태를 AVAILABLE로 복구
-    // HOLD는 ACTIVE/EXPIRED/CONFIRMED만 존재하므로
-    // 사용자 취소를 별도 상태로 표현하지 않고 기존 상태를 유지한다
     reservation.getHold().getShowtimeSeat().markAvailable();
-
-    // 4) 예약 상태를 CANCELLED로 변경
     reservation.cancel();
+  }
+
+  /**
+   * 실제 예약 처리 - 최초 요청에서만 실행
+   * - 처리 성공 시 트랜잭션 커밋 후 Redis에 결과 저장 (커밋 전 저장 시 DB/Redis 불일치 위험)
+   * - 처리 실패 또는 예외 발생 시 lock 해제하여 재시도 허용
+   */
+  private ReservationResponse processReserve(
+    String idempotencyKey,
+    String fingerprint,
+    Long holdId
+  ) {
+    boolean success = false;
+    try {
+      Hold hold = holdRepository.findByIdWithLock(holdId)
+        .orElseThrow(() -> new BusinessException(HoldErrorCode.NOT_FOUND));
+
+      validateReservableHold(hold);
+
+      ShowtimeSeat showtimeSeat = hold.getShowtimeSeat();
+
+      Reservation reservation = Reservation.create(
+        hold,
+        showtimeSeat.getShowtime(),
+        showtimeSeat.getSeat(),
+        hold.getMember()
+      );
+
+      Reservation savedReservation = reservationRepository.save(reservation);
+
+      ReservationResponse response = new ReservationResponse(
+        savedReservation.getId(),
+        hold.getId(),
+        showtimeSeat.getShowtime().getId(),
+        showtimeSeat.getSeat().getId(),
+        hold.getMember().getId(),
+        showtimeSeat.getStatus().name(),
+        hold.getStatus().name()
+      );
+
+      // 트랜잭션 커밋 후 Redis 저장
+      // - 커밋 전 저장 시 롤백되면 DB에는 실패, Redis에는 성공 응답이 남는 불일치 발생
+      // - afterCommit 콜백에서 실행하여 DB 커밋 성공이 보장된 후 저장
+      registerAfterCommit(idempotencyKey, fingerprint, response);
+
+      success = true;
+      return response;
+
+    } finally {
+      // 성공 시에는 afterCommit에서 lock 해제, 실패 시에는 즉시 해제
+      if (!success) {
+        idempotencyRedisRepository.releaseLock(IDEMPOTENCY_PREFIX, idempotencyKey);
+      }
+    }
+  }
+
+  /**
+   * 트랜잭션 커밋 후 Redis 결과 저장 및 lock 해제 등록
+   * - afterCommit: 커밋 성공 시에만 실행
+   * - afterCompletion: 롤백 포함 모든 완료 시 실행 - lock 해제 보장
+   */
+  private void registerAfterCommit(
+    String idempotencyKey,
+    String fingerprint,
+    ReservationResponse response
+  ) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      throw new IllegalStateException("Transaction synchronization is not active");
+    }
+
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+
+      @Override
+      public void afterCommit() {
+        // DB 커밋 성공 후 Redis에 결과 저장 및 lock 해제
+        idempotencyRedisRepository.save(
+          IDEMPOTENCY_PREFIX, idempotencyKey, fingerprint, response, IDEMPOTENCY_TTL);
+      }
+
+      @Override
+      public void afterCompletion(int status) {
+        // 롤백 등 커밋 외 완료 시 lock만 해제 (afterCommit이 실행된 경우 save()에서 이미 해제됨)
+        if (status != STATUS_COMMITTED) {
+          idempotencyRedisRepository.releaseLock(IDEMPOTENCY_PREFIX, idempotencyKey);
+        }
+      }
+    });
   }
 
   /**
@@ -152,6 +233,19 @@ public class ReservationService {
 
     if (status != ReservationStatus.PENDING) {
       throw new BusinessException(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+    }
+  }
+
+  /**
+   * holdId 기반 fingerprint 계산
+   * - 예약 요청의 유일한 식별자는 holdId이므로 holdId를 직렬화하여 hash 계산
+   */
+  private String computeFingerprint(Long holdId) {
+    try {
+      return IdempotencyFingerprintUtil.hash(objectMapper.writeValueAsString(holdId));
+    } catch (JsonProcessingException e) {
+      log.warn("fingerprint 계산 실패 - 빈 문자열 hash로 대체");
+      return IdempotencyFingerprintUtil.hash("");
     }
   }
 }

--- a/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/api/PaymentControllerTest.java
@@ -1,7 +1,9 @@
 package com.pil97.ticketing.payment.api;
 
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.common.exception.GlobalExceptionHandler;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
 import com.pil97.ticketing.payment.application.PaymentService;
@@ -74,9 +76,9 @@ class PaymentControllerTest {
   @DisplayName("POST /payments: 결제 성공 → 201 + SUCCESS 반환")
   void pay_success() throws Exception {
     // given
-    setAuthentication(42L);
+    PaymentResponse response = new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null);
     when(paymentService.pay(any(), any()))
-      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null));
+      .thenReturn(IdempotencyResult.ofNew(response));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -100,9 +102,9 @@ class PaymentControllerTest {
   @DisplayName("POST /payments: forceFailure=true → 201 + FAIL 반환, paidAt null")
   void pay_forceFailure() throws Exception {
     // given
-    setAuthentication(42L);
+    PaymentResponse response = new PaymentResponse(2L, "FAIL", null, null);
     when(paymentService.pay(any(), any()))
-      .thenReturn(new PaymentResponse(2L, "FAIL", null, null));
+      .thenReturn(IdempotencyResult.ofNew(response));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -123,12 +125,11 @@ class PaymentControllerTest {
   }
 
   @Test
-  @DisplayName("POST /payments: Idempotency-Key 헤더 누락 → 400 + PAYMENT-004 반환")
+  @DisplayName("POST /payments: Idempotency-Key 헤더 누락 → 400 + IDEMPOTENCY-003 반환")
   void pay_missingIdempotencyKey_returns400() throws Exception {
     // given
-    setAuthentication(42L);
     when(paymentService.pay(eq(null), any()))
-      .thenThrow(new BusinessException(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING));
+      .thenThrow(new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -142,18 +143,17 @@ class PaymentControllerTest {
           """))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.success").value(false))
-      .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING.getCode()));
+      .andExpect(jsonPath("$.error.code").value(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING.getCode()));
   }
 
   @Test
-  @DisplayName("POST /payments: 동일 Idempotency-Key 재요청 → 201 + 기존 결과 반환")
+  @DisplayName("POST /payments: 동일 Idempotency-Key 재요청 → 200 + 기존 결과 반환")
   void pay_duplicateIdempotencyKey_returnsCachedResponse() throws Exception {
     // given
-    setAuthentication(42L);
-
-    // Redis에서 기존 결과 반환 시나리오
+    PaymentResponse cachedResponse = new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null);
+    // 재요청 시 ofReplayed로 반환 - 컨트롤러에서 200으로 분기
     when(paymentService.pay(eq("duplicate-key-001"), any()))
-      .thenReturn(new PaymentResponse(1L, "SUCCESS", LocalDateTime.of(2026, 4, 6, 10, 0, 0), null));
+      .thenReturn(IdempotencyResult.ofReplayed(cachedResponse));
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -166,7 +166,7 @@ class PaymentControllerTest {
             "forceFailure": false
           }
           """))
-      .andExpect(status().isCreated())
+      .andExpect(status().isOk())
       .andExpect(jsonPath("$.success").value(true))
       .andExpect(jsonPath("$.data.paymentId").value(1))
       .andExpect(jsonPath("$.data.status").value("SUCCESS"));
@@ -175,9 +175,6 @@ class PaymentControllerTest {
   @Test
   @DisplayName("POST /payments: reservationId 누락 → 400")
   void pay_missingReservationId_returns400() throws Exception {
-    // given
-    setAuthentication(42L);
-
     // when & then
     mockMvc.perform(post("/payments")
         .header("Idempotency-Key", "test-key-003")
@@ -193,8 +190,6 @@ class PaymentControllerTest {
   @Test
   @DisplayName("POST /payments: amount가 0이하 → 400")
   void pay_invalidAmount_returns400() throws Exception {
-    // given
-    setAuthentication(42L);
 
     // when & then
     mockMvc.perform(post("/payments")
@@ -212,8 +207,6 @@ class PaymentControllerTest {
   @Test
   @DisplayName("POST /payments: 존재하지 않는 reservationId → 404")
   void pay_reservationNotFound_returns404() throws Exception {
-    // given
-    setAuthentication(42L);
     when(paymentService.pay(any(), any()))
       .thenThrow(new BusinessException(ReservationErrorCode.NOT_FOUND));
 
@@ -235,8 +228,6 @@ class PaymentControllerTest {
   @Test
   @DisplayName("POST /payments: 이미 처리된 예약 → 409")
   void pay_alreadyProcessed_returns409() throws Exception {
-    // given
-    setAuthentication(42L);
     when(paymentService.pay(any(), any()))
       .thenThrow(new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
 
@@ -255,7 +246,7 @@ class PaymentControllerTest {
       .andExpect(jsonPath("$.error.code").value(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED.getCode()));
   }
 
-// ────────────────────────────────────────────────
+  // ────────────────────────────────────────────────
   // POST /payments/{paymentId}/refund
   // ────────────────────────────────────────────────
 
@@ -265,7 +256,9 @@ class PaymentControllerTest {
     // given
     setAuthentication(1L);
     when(paymentService.refund(eq(1L), any(Member.class)))
-      .thenReturn(new PaymentResponse(1L, "REFUNDED", LocalDateTime.of(2026, 4, 6, 10, 0, 0), LocalDateTime.of(2026, 4, 7, 10, 0, 0)));
+      .thenReturn(new PaymentResponse(1L, "REFUNDED",
+        LocalDateTime.of(2026, 4, 6, 10, 0, 0),
+        LocalDateTime.of(2026, 4, 7, 10, 0, 0)));
 
     // when & then
     mockMvc.perform(post("/payments/1/refund"))

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentConcurrencyTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentConcurrencyTest.java
@@ -10,6 +10,7 @@ import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.member.domain.repository.MemberRepository;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
+import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
 import com.pil97.ticketing.payment.domain.repository.PaymentRepository;
 import com.pil97.ticketing.payment.error.PaymentErrorCode;
 import com.pil97.ticketing.reservation.domain.Reservation;
@@ -41,7 +42,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -114,8 +117,20 @@ class PaymentConcurrencyTest {
   @DisplayName("동일 reservationId 동시 결제 10건 요청 시 1건만 SUCCESS, 나머지 9건은 PAYMENT_ALREADY_PROCESSED")
   void pay_sameReservation_concurrently_onlyOneSuccess() throws Exception {
     // given
-    when(idempotencyRedisRepository.find(anyString())).thenReturn(Optional.empty());
-    doNothing().when(idempotencyRedisRepository).save(anyString(), org.mockito.ArgumentMatchers.any());
+    when(idempotencyRedisRepository.find(
+      anyString(),
+      anyString(),
+      anyString(),
+      eq(PaymentResponse.class)
+    )).thenReturn(Optional.empty());
+
+    doNothing().when(idempotencyRedisRepository).save(
+      anyString(),
+      anyString(),
+      anyString(),
+      any(PaymentResponse.class),
+      any()
+    );
 
     Reservation reservation = createPendingReservation();
 

--- a/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/payment/application/PaymentServiceTest.java
@@ -1,8 +1,11 @@
 package com.pil97.ticketing.payment.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.payment.api.dto.request.CreatePaymentRequest;
 import com.pil97.ticketing.payment.api.dto.response.PaymentResponse;
@@ -15,19 +18,22 @@ import com.pil97.ticketing.reservation.domain.ReservationStatus;
 import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
 import com.pil97.ticketing.reservation.error.ReservationErrorCode;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,14 +48,41 @@ class PaymentServiceTest {
   @Mock
   private IdempotencyRedisRepository idempotencyRedisRepository;
 
+  @Mock
+  private ObjectMapper objectMapper;
+
   @InjectMocks
   private PaymentService paymentService;
+
+  @BeforeEach
+  void setUp() {
+    // registerAfterCommit() 내 isSynchronizationActive() 체크를 통과시키기 위해 초기화
+    TransactionSynchronizationManager.initSynchronization();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TransactionSynchronizationManager.clearSynchronization();
+  }
+
+  /**
+   * afterCommit 콜백을 수동으로 실행하는 헬퍼
+   * - 단위 테스트에서는 실제 트랜잭션 커밋이 발생하지 않으므로
+   * 등록된 synchronization을 직접 꺼내 afterCommit()을 호출한다
+   */
+  private void triggerTransactionCommit() {
+    TransactionSynchronizationManager.getSynchronizations()
+      .forEach(sync -> {
+        sync.afterCommit();
+        sync.afterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+      });
+  }
 
   // ===================== 결제 케이스 =====================
 
   @Test
-  @DisplayName("pay: 결제 성공 시 Payment SUCCESS, 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다")
-  void pay_success() {
+  @DisplayName("pay: 결제 성공 시 트랜잭션 커밋 후 Redis에 결과가 저장된다")
+  void pay_success_savesAfterCommit() throws Exception {
     // given
     String idempotencyKey = "test-key-001";
 
@@ -57,6 +90,7 @@ class PaymentServiceTest {
     when(request.getReservationId()).thenReturn(1L);
     when(request.getAmount()).thenReturn(150000);
     when(request.isForceFailure()).thenReturn(false);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{\"reservationId\":1}");
 
     ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
     Hold hold = mock(Hold.class);
@@ -66,7 +100,6 @@ class PaymentServiceTest {
     when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
     when(reservation.getHold()).thenReturn(hold);
 
-    // 비관적 락 조회 stub
     when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
 
     Payment savedPayment = mock(Payment.class);
@@ -75,25 +108,33 @@ class PaymentServiceTest {
     when(savedPayment.getPaidAt()).thenReturn(null);
     when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
 
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenReturn(Optional.empty());
 
     // when
-    PaymentResponse response = paymentService.pay(idempotencyKey, request);
+    IdempotencyResult<PaymentResponse> result = paymentService.pay(idempotencyKey, request);
+
+    // 커밋 전에는 save() 호출되지 않아야 함
+    verify(idempotencyRedisRepository, never()).save(anyString(), anyString(), anyString(), any(), any());
+
+    // afterCommit 수동 실행 - 실제 트랜잭션 커밋 흉내
+    triggerTransactionCommit();
 
     // then
-    assertThat(response).isNotNull();
-    assertThat(response.status()).isEqualTo("SUCCESS");
+    assertThat(result.isReplayed()).isFalse();
+    assertThat(result.getResponse().status()).isEqualTo("SUCCESS");
 
     verify(reservation).confirm();
     verify(showtimeSeat).markReserved();
     verify(hold).confirm();
     verify(savedPayment).success();
-    verify(idempotencyRedisRepository).save(eq(idempotencyKey), any(PaymentResponse.class));
+    // 커밋 후 Redis 저장 확인
+    verify(idempotencyRedisRepository).save(anyString(), eq(idempotencyKey), anyString(), any(PaymentResponse.class), any());
   }
 
   @Test
-  @DisplayName("pay: forceFailure=true이면 Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구된다")
-  void pay_forceFailure() {
+  @DisplayName("pay: forceFailure=true이면 Payment FAIL, 예약 FAILED, HOLD EXPIRED, 좌석 AVAILABLE로 복구되고 lock이 해제된다")
+  void pay_forceFailure_releasesLock() throws Exception {
     // given
     String idempotencyKey = "test-key-002";
 
@@ -101,6 +142,7 @@ class PaymentServiceTest {
     when(request.getReservationId()).thenReturn(1L);
     when(request.getAmount()).thenReturn(150000);
     when(request.isForceFailure()).thenReturn(true);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{\"reservationId\":1}");
 
     ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
     Hold hold = mock(Hold.class);
@@ -110,7 +152,6 @@ class PaymentServiceTest {
     when(reservation.getStatus()).thenReturn(ReservationStatus.PENDING);
     when(reservation.getHold()).thenReturn(hold);
 
-    // 비관적 락 조회 stub
     when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
 
     Payment savedPayment = mock(Payment.class);
@@ -119,87 +160,146 @@ class PaymentServiceTest {
     when(savedPayment.getPaidAt()).thenReturn(null);
     when(paymentRepository.save(any(Payment.class))).thenReturn(savedPayment);
 
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenReturn(Optional.empty());
 
     // when
-    PaymentResponse response = paymentService.pay(idempotencyKey, request);
+    IdempotencyResult<PaymentResponse> result = paymentService.pay(idempotencyKey, request);
 
     // then
-    assertThat(response.status()).isEqualTo("FAIL");
+    assertThat(result.isReplayed()).isFalse();
+    assertThat(result.getResponse().status()).isEqualTo("FAIL");
 
     verify(savedPayment).fail();
     verify(reservation).fail();
     verify(reservation, never()).confirm();
     verify(hold).expire();
     verify(showtimeSeat).markAvailable();
-    verify(idempotencyRedisRepository, never()).save(any(), any());
+    // 결제 실패 시 캐시 저장 안 함
+    verify(idempotencyRedisRepository, never()).save(anyString(), anyString(), anyString(), any(), any());
+    // 결제 실패 시 lock 즉시 해제 - 재시도 허용
+    verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
   }
 
   @Test
-  @DisplayName("pay: 존재하지 않는 reservationId이면 BusinessException(NOT_FOUND)을 던진다")
-  void pay_reservationNotFound_throwsBusinessException() {
+  @DisplayName("pay: 존재하지 않는 reservationId이면 BusinessException(NOT_FOUND)을 던지고 lock이 해제된다")
+  void pay_reservationNotFound_releasesLock() throws Exception {
     // given
     String idempotencyKey = "test-key-003";
 
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
     when(request.getReservationId()).thenReturn(999L);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{\"reservationId\":999}");
+
     when(reservationRepository.findByIdWithLock(999L)).thenReturn(Optional.empty());
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> paymentService.pay(idempotencyKey, request))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(ReservationErrorCode.NOT_FOUND);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(ReservationErrorCode.NOT_FOUND));
 
     verifyNoInteractions(paymentRepository);
+    // 예외 발생 시 finally에서 lock 해제 확인
+    verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
   }
 
   @Test
-  @DisplayName("pay: PENDING이 아닌 예약이면 BusinessException(PAYMENT_ALREADY_PROCESSED)을 던진다")
-  void pay_notPendingReservation_throwsBusinessException() {
+  @DisplayName("pay: PENDING이 아닌 예약이면 BusinessException(PAYMENT_ALREADY_PROCESSED)을 던지고 lock이 해제된다")
+  void pay_notPendingReservation_releasesLock() throws Exception {
     // given
     String idempotencyKey = "test-key-004";
 
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
     when(request.getReservationId()).thenReturn(1L);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{\"reservationId\":1}");
 
     Reservation reservation = mock(Reservation.class);
     when(reservation.getStatus()).thenReturn(ReservationStatus.CONFIRMED);
     when(reservationRepository.findByIdWithLock(1L)).thenReturn(Optional.of(reservation));
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.empty());
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> paymentService.pay(idempotencyKey, request))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED));
 
     verifyNoInteractions(paymentRepository);
+    // 예외 발생 시 finally에서 lock 해제 확인
+    verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
   }
 
   // ===================== idempotency 케이스 =====================
 
   @Test
   @DisplayName("pay: 동일 idempotency key 재요청 시 Redis에서 기존 결과를 반환하고 DB 처리를 하지 않는다")
-  void pay_duplicateKey_returnsExistingResponse() {
+  void pay_duplicateKey_returnsExistingResponse() throws Exception {
     // given
     String idempotencyKey = "duplicate-key-001";
 
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{}");
 
     PaymentResponse cachedResponse = mock(PaymentResponse.class);
-    when(idempotencyRedisRepository.find(idempotencyKey)).thenReturn(Optional.of(cachedResponse));
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenReturn(Optional.of(cachedResponse));
 
     // when
-    PaymentResponse response = paymentService.pay(idempotencyKey, request);
+    IdempotencyResult<PaymentResponse> result = paymentService.pay(idempotencyKey, request);
 
     // then
-    assertThat(response).isEqualTo(cachedResponse);
+    assertThat(result.isReplayed()).isTrue();
+    assertThat(result.getResponse()).isEqualTo(cachedResponse);
+    verifyNoInteractions(reservationRepository);
+    verifyNoInteractions(paymentRepository);
+  }
+
+  @Test
+  @DisplayName("pay: 동일 key로 처리 중인 요청이 있으면 IDEMPOTENCY_IN_PROGRESS 예외를 던진다")
+  void pay_inProgress_throwsBusinessException() throws Exception {
+    // given
+    String idempotencyKey = "in-progress-key-001";
+
+    CreatePaymentRequest request = mock(CreatePaymentRequest.class);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{}");
+
+    // SETNX lock 선점 실패 시나리오
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenThrow(new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_IN_PROGRESS));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.pay(idempotencyKey, request))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_IN_PROGRESS));
+
+    verifyNoInteractions(reservationRepository);
+    verifyNoInteractions(paymentRepository);
+  }
+
+  @Test
+  @DisplayName("pay: 동일 key로 다른 본문이 전달되면 IDEMPOTENCY_KEY_PAYLOAD_MISMATCH 예외를 던진다")
+  void pay_payloadMismatch_throwsBusinessException() throws Exception {
+    // given
+    String idempotencyKey = "mismatch-key-001";
+
+    CreatePaymentRequest request = mock(CreatePaymentRequest.class);
+    when(objectMapper.writeValueAsString(request)).thenReturn("{}");
+
+    // fingerprint 불일치 시나리오
+    when(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(PaymentResponse.class)))
+      .thenThrow(new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_PAYLOAD_MISMATCH));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.pay(idempotencyKey, request))
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_PAYLOAD_MISMATCH));
+
     verifyNoInteractions(reservationRepository);
     verifyNoInteractions(paymentRepository);
   }
@@ -207,16 +307,12 @@ class PaymentServiceTest {
   @Test
   @DisplayName("pay: idempotency key가 null이면 BusinessException(IDEMPOTENCY_KEY_MISSING)을 던진다")
   void pay_nullIdempotencyKey_throwsBusinessException() {
-    // given
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
 
-    // when & then
     assertThatThrownBy(() -> paymentService.pay(null, request))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING));
 
     verifyNoInteractions(reservationRepository);
     verifyNoInteractions(paymentRepository);
@@ -226,16 +322,12 @@ class PaymentServiceTest {
   @Test
   @DisplayName("pay: idempotency key가 blank이면 BusinessException(IDEMPOTENCY_KEY_MISSING)을 던진다")
   void pay_blankIdempotencyKey_throwsBusinessException() {
-    // given
     CreatePaymentRequest request = mock(CreatePaymentRequest.class);
 
-    // when & then
     assertThatThrownBy(() -> paymentService.pay("   ", request))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.IDEMPOTENCY_KEY_MISSING);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING));
 
     verifyNoInteractions(reservationRepository);
     verifyNoInteractions(paymentRepository);
@@ -247,7 +339,6 @@ class PaymentServiceTest {
   @Test
   @DisplayName("refund: 환불 성공 시 Payment REFUNDED, 예약 CANCELLED, HOLD REFUNDED, 좌석 AVAILABLE로 전환된다")
   void refund_success() {
-    // given
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 
@@ -268,14 +359,10 @@ class PaymentServiceTest {
     when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
-    // when
     paymentService.refund(1L, loginMember);
 
-    // then
     verify(payment).refund();
-    // 환불 경로 전용 cancelByRefund() 호출 확인
     verify(reservation).cancelByRefund();
-    // 환불로 종료된 HOLD는 REFUNDED 상태로 전환
     verify(hold).refund();
     verify(showtimeSeat).markAvailable();
   }
@@ -283,7 +370,6 @@ class PaymentServiceTest {
   @Test
   @DisplayName("refund: 타인의 결제 환불 시도 시 BusinessException(REFUND_FORBIDDEN)을 던진다")
   void refund_notOwner_throwsBusinessException() {
-    // given
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(2L);
 
@@ -297,13 +383,10 @@ class PaymentServiceTest {
     when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
-    // when & then
     assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_FORBIDDEN);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(PaymentErrorCode.REFUND_FORBIDDEN));
 
     verify(payment, never()).refund();
   }
@@ -311,7 +394,6 @@ class PaymentServiceTest {
   @Test
   @DisplayName("refund: SUCCESS 상태가 아닌 환불 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
   void refund_notSuccess_throwsBusinessException() {
-    // given
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 
@@ -326,13 +408,10 @@ class PaymentServiceTest {
     when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
-    // when & then
     assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED));
 
     verify(payment, never()).refund();
   }
@@ -340,7 +419,6 @@ class PaymentServiceTest {
   @Test
   @DisplayName("refund: 이미 환불된 결제 시도 시 BusinessException(REFUND_NOT_ALLOWED)을 던진다")
   void refund_alreadyRefunded_throwsBusinessException() {
-    // given
     Member loginMember = mock(Member.class);
     when(loginMember.getId()).thenReturn(1L);
 
@@ -355,13 +433,10 @@ class PaymentServiceTest {
     when(payment.getReservation()).thenReturn(reservation);
     when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
 
-    // when & then
     assertThatThrownBy(() -> paymentService.refund(1L, loginMember))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(PaymentErrorCode.REFUND_NOT_ALLOWED));
 
     verify(payment, never()).refund();
   }
@@ -369,16 +444,12 @@ class PaymentServiceTest {
   @Test
   @DisplayName("refund: 존재하지 않는 paymentId 환불 시도 시 BusinessException(PAYMENT_NOT_FOUND)을 던진다")
   void refund_paymentNotFound_throwsBusinessException() {
-    // given
     Member loginMember = mock(Member.class);
     when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
 
-    // when & then
     assertThatThrownBy(() -> paymentService.refund(999L, loginMember))
       .isInstanceOf(BusinessException.class)
-      .satisfies(ex -> {
-        BusinessException be = (BusinessException) ex;
-        assertThat(be.getErrorCode()).isEqualTo(PaymentErrorCode.PAYMENT_NOT_FOUND);
-      });
+      .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+        .isEqualTo(PaymentErrorCode.PAYMENT_NOT_FOUND));
   }
 }

--- a/src/test/java/com/pil97/ticketing/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/reservation/application/ReservationServiceTest.java
@@ -1,21 +1,27 @@
 package com.pil97.ticketing.reservation.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pil97.ticketing.common.error.IdempotencyErrorCode;
 import com.pil97.ticketing.common.exception.BusinessException;
 import com.pil97.ticketing.hold.domain.Hold;
 import com.pil97.ticketing.hold.domain.HoldStatus;
+import com.pil97.ticketing.hold.domain.repository.HoldRepository;
 import com.pil97.ticketing.hold.error.HoldErrorCode;
+import com.pil97.ticketing.infra.idempotency.IdempotencyRedisRepository;
+import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
 import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
 import com.pil97.ticketing.reservation.domain.Reservation;
 import com.pil97.ticketing.reservation.domain.ReservationStatus;
-import com.pil97.ticketing.reservation.error.ReservationErrorCode;
-import com.pil97.ticketing.hold.domain.repository.HoldRepository;
 import com.pil97.ticketing.reservation.domain.repository.ReservationRepository;
+import com.pil97.ticketing.reservation.error.ReservationErrorCode;
 import com.pil97.ticketing.seat.domain.Seat;
 import com.pil97.ticketing.showtime.domain.Showtime;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeat;
 import com.pil97.ticketing.showtimeseat.domain.ShowtimeSeatStatus;
 import com.pil97.ticketing.showtimeseat.error.ShowtimeSeatErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -30,6 +38,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -42,17 +52,48 @@ class ReservationServiceTest {
   @Mock
   private ReservationRepository reservationRepository;
 
+  @Mock
+  private IdempotencyRedisRepository idempotencyRedisRepository;
+
+  @Mock
+  private ObjectMapper objectMapper;
+
   @InjectMocks
   private ReservationService reservationService;
+
+  @BeforeEach
+  void setUp() {
+    // registerAfterCommit() 내 isSynchronizationActive() 체크를 통과시키기 위해 초기화
+    TransactionSynchronizationManager.initSynchronization();
+  }
+
+  @AfterEach
+  void tearDown() {
+    TransactionSynchronizationManager.clearSynchronization();
+  }
+
+  /**
+   * 트랜잭션 커밋 흐름을 수동으로 재현하는 헬퍼
+   * - 단위 테스트에서는 실제 트랜잭션 커밋이 발생하지 않으므로
+   * 등록된 synchronization을 직접 꺼내 콜백을 호출한다
+   */
+  private void triggerTransactionCommit() {
+    TransactionSynchronizationManager.getSynchronizations()
+      .forEach(sync -> {
+        sync.afterCommit();
+        sync.afterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+      });
+  }
 
   @Nested
   @DisplayName("reserve")
   class Reserve {
 
     @Test
-    @DisplayName("유효한 HOLD면 예약을 PENDING 상태로 생성한다")
-    void reserve_success() {
+    @DisplayName("유효한 HOLD면 예약을 PENDING 상태로 생성하고 커밋 후 Redis에 저장된다")
+    void reserve_success_savesAfterCommit() throws Exception {
       // given
+      String idempotencyKey = "test-key-001";
       Long holdId = 1L;
       Long reservationId = 1L;
       Long showtimeId = 10L;
@@ -66,7 +107,11 @@ class ReservationServiceTest {
       Member member = mock(Member.class);
       Reservation savedReservation = mock(Reservation.class);
 
-      given(holdRepository.findById(holdId)).willReturn(Optional.of(hold));
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.empty());
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+
+      given(holdRepository.findByIdWithLock(holdId)).willReturn(Optional.of(hold));
       given(hold.getId()).willReturn(holdId);
       given(hold.getStatus()).willReturn(HoldStatus.ACTIVE);
       given(hold.getExpiresAt()).willReturn(LocalDateTime.now().plusMinutes(5));
@@ -85,104 +130,219 @@ class ReservationServiceTest {
       given(reservationRepository.save(any(Reservation.class))).willReturn(savedReservation);
 
       // when
-      ReservationResponse response = reservationService.reserve(holdId);
+      IdempotencyResult<ReservationResponse> result = reservationService.reserve(idempotencyKey, holdId);
+
+      // 커밋 전에는 Redis 저장 안 됨
+      verify(idempotencyRedisRepository, never()).save(anyString(), anyString(), anyString(), any(), any());
+
+      // afterCommit 수동 실행
+      triggerTransactionCommit();
 
       // then
-      assertThat(response.reservationId()).isEqualTo(reservationId);
-      assertThat(response.holdId()).isEqualTo(holdId);
-      assertThat(response.showtimeId()).isEqualTo(showtimeId);
-      assertThat(response.seatId()).isEqualTo(seatId);
-      assertThat(response.memberId()).isEqualTo(memberId);
-      // 결제 완료 전이므로 좌석/HOLD 상태 변경 없음
-      assertThat(response.seatStatus()).isEqualTo("HELD");
-      assertThat(response.holdStatus()).isEqualTo("ACTIVE");
+      assertThat(result.isReplayed()).isFalse();
+      assertThat(result.getResponse().reservationId()).isEqualTo(reservationId);
+      assertThat(result.getResponse().holdId()).isEqualTo(holdId);
+      assertThat(result.getResponse().seatStatus()).isEqualTo("HELD");
+      assertThat(result.getResponse().holdStatus()).isEqualTo("ACTIVE");
 
       verify(reservationRepository).save(any(Reservation.class));
       // 좌석/HOLD 상태 변경은 PaymentService에서 처리하므로 호출되지 않아야 함
       verify(showtimeSeat, never()).markReserved();
       verify(hold, never()).confirm();
+      // 커밋 후 Redis 저장 확인
+      verify(idempotencyRedisRepository).save(anyString(), eq(idempotencyKey), anyString(), any(ReservationResponse.class), any());
     }
 
     @Test
-    @DisplayName("존재하지 않는 HOLD면 예외가 발생한다")
-    void reserve_fail_when_hold_not_found() {
+    @DisplayName("동일 key + 동일 본문 재요청 시 Redis 캐시 응답을 반환하고 DB 처리를 하지 않는다")
+    void reserve_duplicateKey_returnsExistingResponse() throws Exception {
       // given
+      String idempotencyKey = "duplicate-key-001";
       Long holdId = 1L;
-      given(holdRepository.findById(holdId)).willReturn(Optional.empty());
+
+      ReservationResponse cachedResponse = mock(ReservationResponse.class);
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.of(cachedResponse));
+
+      // when
+      IdempotencyResult<ReservationResponse> result = reservationService.reserve(idempotencyKey, holdId);
+
+      // then
+      assertThat(result.isReplayed()).isTrue();
+      assertThat(result.getResponse()).isEqualTo(cachedResponse);
+      verifyNoInteractions(holdRepository);
+      verifyNoInteractions(reservationRepository);
+    }
+
+    @Test
+    @DisplayName("동일 key로 처리 중인 요청이 있으면 IDEMPOTENCY_IN_PROGRESS 예외를 던진다")
+    void reserve_inProgress_throwsBusinessException() throws Exception {
+      // given
+      String idempotencyKey = "in-progress-key-001";
+      Long holdId = 1L;
+
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willThrow(new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_IN_PROGRESS));
 
       // when & then
-      assertThatThrownBy(() -> reservationService.reserve(holdId))
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(HoldErrorCode.NOT_FOUND);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_IN_PROGRESS));
 
-      verify(reservationRepository, never()).save(any());
+      verifyNoInteractions(holdRepository);
+      verifyNoInteractions(reservationRepository);
     }
 
     @Test
-    @DisplayName("HOLD 상태가 ACTIVE가 아니면 예외가 발생한다")
-    void reserve_fail_when_hold_not_active() {
+    @DisplayName("동일 key로 다른 본문이 전달되면 IDEMPOTENCY_KEY_PAYLOAD_MISMATCH 예외를 던진다")
+    void reserve_payloadMismatch_throwsBusinessException() throws Exception {
       // given
+      String idempotencyKey = "mismatch-key-001";
+      Long holdId = 1L;
+
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willThrow(new BusinessException(IdempotencyErrorCode.IDEMPOTENCY_KEY_PAYLOAD_MISMATCH));
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_PAYLOAD_MISMATCH));
+
+      verifyNoInteractions(holdRepository);
+      verifyNoInteractions(reservationRepository);
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key가 null이면 IDEMPOTENCY_KEY_MISSING 예외를 던진다")
+    void reserve_nullIdempotencyKey_throwsBusinessException() {
+      // when & then
+      assertThatThrownBy(() -> reservationService.reserve(null, 1L))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING));
+
+      verifyNoInteractions(holdRepository);
+      verifyNoInteractions(reservationRepository);
+      verifyNoInteractions(idempotencyRedisRepository);
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key가 blank이면 IDEMPOTENCY_KEY_MISSING 예외를 던진다")
+    void reserve_blankIdempotencyKey_throwsBusinessException() {
+      // when & then
+      assertThatThrownBy(() -> reservationService.reserve("   ", 1L))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(IdempotencyErrorCode.IDEMPOTENCY_KEY_MISSING));
+
+      verifyNoInteractions(holdRepository);
+      verifyNoInteractions(reservationRepository);
+      verifyNoInteractions(idempotencyRedisRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 HOLD면 예외가 발생하고 lock이 해제된다")
+    void reserve_holdNotFound_releasesLock() throws Exception {
+      // given
+      String idempotencyKey = "test-key-002";
+      Long holdId = 1L;
+
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.empty());
+      given(holdRepository.findByIdWithLock(holdId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(HoldErrorCode.NOT_FOUND));
+
+      verify(reservationRepository, never()).save(any());
+      // 예외 발생 시 finally에서 lock 해제 확인
+      verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
+    }
+
+    @Test
+    @DisplayName("HOLD 상태가 ACTIVE가 아니면 예외가 발생하고 lock이 해제된다")
+    void reserve_holdNotActive_releasesLock() throws Exception {
+      // given
+      String idempotencyKey = "test-key-003";
       Long holdId = 1L;
       Hold hold = mock(Hold.class);
 
-      given(holdRepository.findById(holdId)).willReturn(Optional.of(hold));
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.empty());
+      given(holdRepository.findByIdWithLock(holdId)).willReturn(Optional.of(hold));
       given(hold.getStatus()).willReturn(HoldStatus.CONFIRMED);
 
       // when & then
-      assertThatThrownBy(() -> reservationService.reserve(holdId))
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(HoldErrorCode.NOT_ACTIVE);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(HoldErrorCode.NOT_ACTIVE));
 
       verify(reservationRepository, never()).save(any());
-      verify(hold, never()).confirm();
+      verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
     }
 
     @Test
-    @DisplayName("HOLD가 만료되었으면 예외가 발생한다")
-    void reserve_fail_when_hold_expired() {
+    @DisplayName("HOLD가 만료되었으면 예외가 발생하고 lock이 해제된다")
+    void reserve_holdExpired_releasesLock() throws Exception {
       // given
+      String idempotencyKey = "test-key-004";
       Long holdId = 1L;
       Hold hold = mock(Hold.class);
 
-      given(holdRepository.findById(holdId)).willReturn(Optional.of(hold));
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.empty());
+      given(holdRepository.findByIdWithLock(holdId)).willReturn(Optional.of(hold));
       given(hold.getStatus()).willReturn(HoldStatus.ACTIVE);
       given(hold.getExpiresAt()).willReturn(LocalDateTime.now().minusMinutes(1));
 
       // when & then
-      assertThatThrownBy(() -> reservationService.reserve(holdId))
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(HoldErrorCode.EXPIRED);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(HoldErrorCode.EXPIRED));
 
       verify(reservationRepository, never()).save(any());
-      verify(hold, never()).confirm();
+      verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
     }
 
     @Test
-    @DisplayName("연결된 좌석 상태가 HELD가 아니면 예외가 발생한다")
-    void reserve_fail_when_showtime_seat_not_held() {
+    @DisplayName("연결된 좌석 상태가 HELD가 아니면 예외가 발생하고 lock이 해제된다")
+    void reserve_seatNotHeld_releasesLock() throws Exception {
       // given
+      String idempotencyKey = "test-key-005";
       Long holdId = 1L;
       Hold hold = mock(Hold.class);
       ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
 
-      given(holdRepository.findById(holdId)).willReturn(Optional.of(hold));
+      given(objectMapper.writeValueAsString(holdId)).willReturn("1");
+      given(idempotencyRedisRepository.find(anyString(), eq(idempotencyKey), anyString(), eq(ReservationResponse.class)))
+        .willReturn(Optional.empty());
+      given(holdRepository.findByIdWithLock(holdId)).willReturn(Optional.of(hold));
       given(hold.getStatus()).willReturn(HoldStatus.ACTIVE);
       given(hold.getExpiresAt()).willReturn(LocalDateTime.now().plusMinutes(5));
       given(hold.getShowtimeSeat()).willReturn(showtimeSeat);
       given(showtimeSeat.getStatus()).willReturn(ShowtimeSeatStatus.RESERVED);
 
       // when & then
-      assertThatThrownBy(() -> reservationService.reserve(holdId))
+      assertThatThrownBy(() -> reservationService.reserve(idempotencyKey, holdId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ShowtimeSeatErrorCode.NOT_HELD);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(ShowtimeSeatErrorCode.NOT_HELD));
 
       verify(reservationRepository, never()).save(any());
-      verify(showtimeSeat, never()).markReserved();
-      verify(hold, never()).confirm();
+      verify(idempotencyRedisRepository).releaseLock(anyString(), eq(idempotencyKey));
     }
   }
 
@@ -201,7 +361,6 @@ class ReservationServiceTest {
       ShowtimeSeat showtimeSeat = mock(ShowtimeSeat.class);
 
       given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
-      // PENDING 상태만 직접 취소 허용
       given(reservation.getStatus()).willReturn(ReservationStatus.PENDING);
       given(reservation.getHold()).willReturn(hold);
       given(hold.getShowtimeSeat()).willReturn(showtimeSeat);
@@ -217,7 +376,7 @@ class ReservationServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 예약이면 예외가 발생한다")
-    void cancel_fail_when_reservation_not_found() {
+    void cancel_reservationNotFound() {
       // given
       Long reservationId = 1L;
       given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
@@ -225,15 +384,15 @@ class ReservationServiceTest {
       // when & then
       assertThatThrownBy(() -> reservationService.cancel(reservationId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ReservationErrorCode.NOT_FOUND);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(ReservationErrorCode.NOT_FOUND));
 
       verify(reservationRepository).findById(reservationId);
     }
 
     @Test
     @DisplayName("CONFIRMED 상태의 예약은 직접 취소 불가 - 환불 API 사용 안내")
-    void cancel_fail_when_reservation_confirmed() {
+    void cancel_confirmed_requiresRefund() {
       // given
       Long reservationId = 1L;
       Reservation reservation = mock(Reservation.class);
@@ -242,11 +401,10 @@ class ReservationServiceTest {
       given(reservation.getStatus()).willReturn(ReservationStatus.CONFIRMED);
 
       // when & then
-      // CONFIRMED 예약은 POST /payments/{paymentId}/refund 를 통해서만 취소 가능
       assertThatThrownBy(() -> reservationService.cancel(reservationId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_REQUIRES_REFUND));
 
       verify(reservation, never()).cancel();
       verify(reservation, never()).getHold();
@@ -254,7 +412,7 @@ class ReservationServiceTest {
 
     @Test
     @DisplayName("FAILED 상태의 예약은 취소할 수 없다")
-    void cancel_fail_when_reservation_failed() {
+    void cancel_failed_notAllowed() {
       // given
       Long reservationId = 1L;
       Reservation reservation = mock(Reservation.class);
@@ -265,8 +423,8 @@ class ReservationServiceTest {
       // when & then
       assertThatThrownBy(() -> reservationService.cancel(reservationId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED));
 
       verify(reservation, never()).cancel();
       verify(reservation, never()).getHold();
@@ -274,7 +432,7 @@ class ReservationServiceTest {
 
     @Test
     @DisplayName("이미 취소된 예약은 취소할 수 없다")
-    void cancel_fail_when_reservation_already_cancelled() {
+    void cancel_alreadyCancelled_notAllowed() {
       // given
       Long reservationId = 1L;
       Reservation reservation = mock(Reservation.class);
@@ -285,8 +443,8 @@ class ReservationServiceTest {
       // when & then
       assertThatThrownBy(() -> reservationService.cancel(reservationId))
         .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED);
+        .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+          .isEqualTo(ReservationErrorCode.RESERVATION_CANCEL_NOT_ALLOWED));
 
       verify(reservation, never()).cancel();
       verify(reservation, never()).getHold();


### PR DESCRIPTION
## What
- `IdempotencyRedisRepository` 제네릭 리팩토링 (`PaymentResponse` 강결합 제거)
- `IdempotencyEntry` 추가 — fingerprint + responseBody를 단일 JSON envelope로 저장
- `IdempotencyFingerprintUtil` 추가 — 요청 본문 SHA-256 hash 생성
- `IdempotencyResult<T>` 추가 — 신규(201) / 재요청(200) 상태코드 분기용 래퍼
- `IdempotencyErrorCode` 추가 — 멱등성 공통 에러코드 (`common/error`)
- `PaymentErrorCode` — `IDEMPOTENCY_KEY_MISSING` 제거 (공통 에러로 이동)
- `HoldRepository` — `findByIdWithLock()` 추가 (비관적 락)
- `ReservationService.reserve()` — Idempotency Key 멱등성 적용
- `ReservationController` — `Idempotency-Key` 헤더 추출 및 전달, 201/200 분기
- `PaymentService.pay()` — 리팩토링된 제네릭 구조로 교체
- `PaymentController` — 201/200 분기 적용
- `PaymentControllerTest`, `PaymentServiceTest`, `PaymentConcurrencyTest`, `ReservationServiceTest` 수정

## Why
- TASK-036에서 결제 API에만 멱등성을 구현했으나 `IdempotencyRedisRepository`가
  `PaymentResponse`에 강결합되어 타 도메인에서 재사용할 수 없는 구조였다.
- `ReservationService.reserve()`는 멱등성 보장이 없어 네트워크 재시도나
  클라이언트 중복 요청 시 동일 holdId로 예약이 2건 생성될 수 있었다.
- 서로 다른 `Idempotency-Key`로 동일 holdId에 동시 요청 시 중복 예약을 막을
  DB 레벨 보호 수단이 없었다.

## How
- `IdempotencyRedisRepository`를 `Class<T>` 기반 제네릭으로 리팩토링하여
  도메인별 prefix/TTL 주입 방식으로 재사용 가능하도록 변경
- SETNX 기반 in-progress lock으로 동시 신규 요청 차단
  - `result 조회 → fingerprint 검증 → 결과 없을 때만 lock 선점` 순서로 설계하여
    재요청이 불필요하게 409를 받지 않도록 처리
- 요청 본문 SHA-256 fingerprint 저장으로 동일 key + 다른 본문 재사용 차단 (409)
- 트랜잭션 커밋 후 Redis 저장 (`afterCommit` 콜백) — 커밋 전 저장 시
  롤백되면 DB에는 실패, Redis에는 성공 응답이 남는 불일치 방지
- `HoldRepository.findByIdWithLock()`으로 서로 다른 key의 동시 예약 생성을
  DB 레벨에서 직렬화
- `IdempotencyResult<T>`로 신규(201) / 재요청(200) 상태코드 분기

## Test
- `./gradlew clean test -Dspring.profiles.active=test` 통과
- 추가/수정된 테스트
  - `ReservationServiceTest`: 신규/중복 응답, payload 불일치, key 누락, 예외 시 lock 해제 케이스 검증
  - `PaymentServiceTest`: 리팩토링 후 멱등성 시나리오 재검증, afterCommit 저장 흐름 검증
  - `PaymentControllerTest`: 신규 201 / 재요청 200 분기 검증
  - `PaymentConcurrencyTest`: 동일 reservationId 동시 결제 시 1건만 성공 검증
  
## Notes
- `IdempotencyRedisRepository`는 Bean 1개 + prefix/TTL 파라미터 주입 방식으로
  단순하게 구현 (인터페이스 추출 등 오버엔지니어링 방지)
- 결제/예약 실패 시 캐시 저장 안 함 — 재시도 허용
- 취소 API는 이번 범위에서 제외 — PENDING 상태 전이 가드로 중복 보호

closes #94 