### PR TITLE
feat(TASK-031): Redis 슬라이딩 윈도우 기반 Rate Limiting 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 트래픽 폭증 대응 — Redis Sorted Set 기반 대기열로 입장 순서 제어
 - 결제 중복 처리 방지 — Idempotency Key 기반 멱등성 보장
 - 인증 보안 강화 — RefreshToken Rotation + Redis 블랙리스트 로그아웃
+- 과도한 반복 요청 차단 — Redis 슬라이딩 윈도우 기반 Rate Limiting
 
 > Java 17 / Spring Boot 3.4.3 / MariaDB / Redis / Docker Compose / GitHub
 > Actions
@@ -75,13 +76,14 @@ sequenceDiagram
 
 ## 핵심 기술 결정
 
-| 결정           | 선택                      | 대안 대비 이유                                                                       |
-|--------------|-------------------------|--------------------------------------------------------------------------------|
-| 동시성 제어       | Redis 분산락 (Redisson)    | 비관적 락은 DB 커넥션을 점유해 트래픽 폭증 시 DB 부하 집중. Redis 분산락은 DB 외부에서 락을 관리해 부하 분산 가능       |
-| 대기열          | Redis Sorted Set        | score를 진입 timestamp로 사용해 O(log N)으로 순번 조회/정렬 가능. 별도 MQ 없이 단일 Redis로 처리         |
-| RefreshToken | Rotation 방식             | 토큰 탈취 시 피해자가 재사용을 시도하면 Redis 불일치로 즉시 감지 후 강제 로그아웃                              |
-| 결제 멱등성       | Idempotency Key + Redis | 동일 key 재요청은 기존 결과 반환, 동일 key+다른 payload는 차단, 처리 중 중복 요청은 in-progress lock으로 차단 |
-| 이벤트 캐시       | Redis Cache (TTL 10분)   | 공연 목록은 변경 빈도가 낮고 조회 빈도가 높음. 캐시로 DB 조회 부하 감소                                    |
+| 결정            | 선택                      | 대안 대비 이유                                                                               |
+|---------------|-------------------------|----------------------------------------------------------------------------------------|
+| 동시성 제어        | Redis 분산락 (Redisson)    | 비관적 락은 DB 커넥션을 점유해 트래픽 폭증 시 DB 부하 집중. Redis 분산락은 DB 외부에서 락을 관리해 부하 분산 가능               |
+| 대기열           | Redis Sorted Set        | score를 진입 timestamp로 사용해 O(log N)으로 순번 조회/정렬 가능. 별도 MQ 없이 단일 Redis로 처리                 |
+| RefreshToken  | Rotation 방식             | 토큰 탈취 시 피해자가 재사용을 시도하면 Redis 불일치로 즉시 감지 후 강제 로그아웃                                      |
+| 결제 멱등성        | Idempotency Key + Redis | 동일 key 재요청은 기존 결과 반환, 동일 key+다른 payload는 차단, 처리 중 중복 요청은 in-progress lock으로 차단         |
+| 이벤트 캐시        | Redis Cache (TTL 10분)   | 공연 목록은 변경 빈도가 낮고 조회 빈도가 높음. 캐시로 DB 조회 부하 감소                                            |
+| Rate Limiting | Redis 슬라이딩 윈도우          | 고정 윈도우는 경계에서 2배 허용 취약점 존재. 슬라이딩 윈도우는 Sorted Set + Lua Script로 원자적 카운트, 정확한 시간 기반 제한 가능 |
 
 ---
 
@@ -131,6 +133,7 @@ sequenceDiagram
 - HOLD 만료 해제 스케줄링 (30초 주기)
 - N+1 제거 (fetch join) + 인덱스 설계
 - GitHub Actions CI
+- Rate Limiting — Redis 슬라이딩 윈도우 (HOLD 5회/60초, 예약·결제 3회/60초, AOP 기반 적용)
 
 ---
 
@@ -250,6 +253,7 @@ docker compose up -d
 | `PAYMENT-xxx`       | 결제                                 |
 | `IDEMPOTENCY-xxx`   | 멱등성 (중복 요청 / payload 불일치 / key 누락) |
 | `QUEUE-xxx`         | 대기열                                |
+| `RATE-LIMIT-xxx`    | Rate Limiting (요청 횟수 초과)           |
 
 전체 에러 코드는 각 도메인 패키지의 `XxxErrorCode.java`를 참고하세요.
 

--- a/src/main/java/com/pil97/ticketing/common/error/RateLimitErrorCode.java
+++ b/src/main/java/com/pil97/ticketing/common/error/RateLimitErrorCode.java
@@ -1,0 +1,21 @@
+package com.pil97.ticketing.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Rate Limit 도메인 에러코드
+ * - RATE_LIMIT_EXCEEDED: 허용 횟수 초과 시 429 반환
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RateLimitErrorCode implements ErrorCode {
+
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE-LIMIT-001",
+    "요청 횟수 한도를 초과했습니다. 잠시 후 다시 시도해주세요.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/pil97/ticketing/common/ratelimit/RateLimit.java
+++ b/src/main/java/com/pil97/ticketing/common/ratelimit/RateLimit.java
@@ -1,0 +1,40 @@
+package com.pil97.ticketing.common.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Rate Limit 적용 어노테이션
+ *
+ * <p>Controller 메서드에 붙이면 RateLimitAspect가 요청 횟수를 검사한다.
+ *
+ * <p>기본 제한값은 10회 / 60초다.
+ * 이는 실제 운영 로그 기반의 최종값이 아니라, 포트폴리오 단계에서의 초기 보호 정책값이다.
+ *
+ * <p>정상적인 예약 흐름에서는 사용자가 1분 안에 동일한 HOLD, 예약, 결제 API를
+ * 10회 이상 호출할 가능성이 낮다.
+ * 반면 버튼 연타, 프론트 버그, 자동화 요청은 짧은 시간 안에 반복 호출을 만들 수 있으므로
+ * 이를 조기에 차단하기 위한 기본값으로 설정한다.
+ *
+ * <p>단, API별 위험도와 사용 패턴이 다르므로 Controller 적용 시 limit/windowSeconds 값을
+ * 명시적으로 조정할 수 있다.
+ * 예: HOLD는 비교적 넉넉하게, 예약 생성과 결제는 더 엄격하게 제한한다.
+ *
+ * <ul>
+ *   <li>api: Redis Key의 {api} 세그먼트, 적용 대상 API를 식별한다.</li>
+ *   <li>limit: 윈도우 내 허용 최대 요청 횟수. 기본값은 10회다.</li>
+ *   <li>windowSeconds: 슬라이딩 윈도우 크기. 기본값은 60초다.</li>
+ * </ul>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+  RateLimitApi api();
+
+  int limit() default 10;
+
+  int windowSeconds() default 60;
+}

--- a/src/main/java/com/pil97/ticketing/common/ratelimit/RateLimitApi.java
+++ b/src/main/java/com/pil97/ticketing/common/ratelimit/RateLimitApi.java
@@ -1,0 +1,14 @@
+package com.pil97.ticketing.common.ratelimit;
+
+/**
+ * Rate Limit 적용 대상 API 식별자 enum
+ * - Redis Key의 {api} 세그먼트로 사용된다
+ * - 문자열 하드코딩을 방지하고 오타로 인한 key 불일치를 컴파일 타임에 차단한다
+ * - 예: rate:limit:42:HOLD
+ */
+public enum RateLimitApi {
+
+  HOLD,
+  RESERVATION,
+  PAYMENT
+}

--- a/src/main/java/com/pil97/ticketing/hold/api/HoldController.java
+++ b/src/main/java/com/pil97/ticketing/hold/api/HoldController.java
@@ -1,5 +1,7 @@
 package com.pil97.ticketing.hold.api;
 
+import com.pil97.ticketing.common.ratelimit.RateLimit;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
 import com.pil97.ticketing.common.response.ApiResponse;
 import com.pil97.ticketing.hold.api.dto.request.HoldCreateRequest;
 import com.pil97.ticketing.hold.api.dto.response.HoldResponse;
@@ -20,26 +22,20 @@ public class HoldController {
 
   /**
    * POST /showtimes/{showtimeId}/hold
-   * <p>
-   * 이 API의 목적:
-   * - 특정 회차의 좌석을 일정 시간 동안 선점(HOLD)한다.
-   * <p>
-   * 상태코드 정책:
-   * - 선점 성공 시 201 Created
-   * <p>
-   * 응답 정책:
-   * - 표준 응답 포맷(ApiResponse)로 감싸서 반환
+   *
+   * <p>특정 회차의 좌석을 일정 시간 동안 선점(HOLD)한다.
+   *
+   * <p>Rate Limit 정책: 60초 윈도우 내 최대 5회
+   * HOLD는 DB Lock과 Redis 분산락이 중복 선점을 막지만
+   * 반복 요청 자체의 부하를 줄이기 위해 제한을 적용한다.
    */
+  @RateLimit(api = RateLimitApi.HOLD, limit = 5, windowSeconds = 60)
   @PostMapping("/showtimes/{showtimeId}/hold")
   public ResponseEntity<ApiResponse<HoldResponse>> hold(
     @PathVariable Long showtimeId,
     @Valid @RequestBody HoldCreateRequest request
   ) {
-
-    // 서비스 호출: 좌석 선점 처리
     HoldResponse response = holdService.hold(showtimeId, request);
-
-    // 201 Created + 표준 응답
     return ResponseEntity
       .status(HttpStatus.CREATED)
       .body(ApiResponse.success(response));

--- a/src/main/java/com/pil97/ticketing/infra/ratelimit/RateLimitAspect.java
+++ b/src/main/java/com/pil97/ticketing/infra/ratelimit/RateLimitAspect.java
@@ -1,0 +1,62 @@
+package com.pil97.ticketing.infra.ratelimit;
+
+import com.pil97.ticketing.common.ratelimit.RateLimit;
+import com.pil97.ticketing.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate Limit AOP
+ *
+ * <p>@RateLimit 어노테이션이 붙은 Controller 메서드 실행 전에 요청 횟수를 검사한다.
+ *
+ * <p>AOP 방식을 선택한 이유:
+ * Controller 코드를 수정하지 않고 어노테이션 선언만으로 Rate Limit 정책을 적용할 수 있다.
+ * 새 API 추가 시 @RateLimit만 붙이면 되므로 OCP를 준수한다.
+ *
+ * <p>memberId 추출:
+ * Spring Security의 SecurityContextHolder에서 인증된 사용자를 꺼낸다.
+ * 비인증 요청은 현재 Rate Limit 적용 범위 외이므로 통과시킨다.
+ */
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+  private final RateLimitService rateLimitService;
+
+  /**
+   * @param rateLimit 메서드에 선언된 @RateLimit 어노테이션
+   * @RateLimit 어노테이션이 붙은 메서드 실행 전 호출
+   *
+   * <p>어노테이션에서 api, limit, windowSeconds를 읽어 RateLimitService에 위임한다.
+   * 인증되지 않은 요청은 현재 범위 외이므로 통과시킨다.
+   */
+  @Before("@annotation(rateLimit)")
+  public void checkRateLimit(RateLimit rateLimit) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return;
+    }
+
+    Object principal = authentication.getPrincipal();
+
+    if (!(principal instanceof Member member)) {
+      return;
+    }
+
+    rateLimitService.check(
+      member.getId(),
+      rateLimit.api(),
+      rateLimit.limit(),
+      rateLimit.windowSeconds()
+    );
+  }
+}

--- a/src/main/java/com/pil97/ticketing/infra/ratelimit/RateLimitService.java
+++ b/src/main/java/com/pil97/ticketing/infra/ratelimit/RateLimitService.java
@@ -1,0 +1,147 @@
+package com.pil97.ticketing.infra.ratelimit;
+
+import com.pil97.ticketing.common.error.RateLimitErrorCode;
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Redis Sorted Set 기반 슬라이딩 윈도우 Rate Limiter 구현체
+ *
+ * <p>고정 윈도우(Fixed Window) 방식은 윈도우 경계에서 최대 2배 요청이 허용되는 취약점이 있다.
+ * 슬라이딩 윈도우는 요청 타임스탬프를 Sorted Set으로 관리하므로
+ * 어느 시점을 기준으로 해도 정확히 windowSeconds 이내의 요청 수만 카운트한다.
+ *
+ * <p>Lua Script를 사용하는 이유:
+ * ZREMRANGEBYSCORE, ZCARD, ZADD, EXPIRE 4개 명령을 개별 실행하면
+ * 멀티스레드 환경에서 카운트가 틀릴 수 있다.
+ * Lua Script는 Redis에서 원자적으로 실행되므로 이 문제를 방지한다.
+ *
+ * <p>ZSET member를 "timestamp:UUID" 형식으로 저장하는 이유:
+ * 동일 밀리초에 요청이 겹치면 ZADD가 score 기준으로 덮어쓰기를 하지 않고
+ * member가 중복되면 기존 항목을 업데이트한다.
+ * UUID를 붙여 member를 유일하게 만들면 동시 요청이 모두 정확하게 카운트된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitService {
+
+  private final StringRedisTemplate stringRedisTemplate;
+
+  /**
+   * Lua Script: 슬라이딩 윈도우 원자적 실행
+   * <p>
+   * KEYS[1]: Redis Key (rate:limit:{memberId}:{api})
+   * ARGV[1]: 현재 타임스탬프 (밀리초)
+   * ARGV[2]: 윈도우 시작 타임스탬프 (현재 - windowSeconds * 1000)
+   * ARGV[3]: ZSET member (timestamp:UUID)
+   * ARGV[4]: 허용 최대 횟수
+   * ARGV[5]: Key TTL (초)
+   * <p>
+   * 반환값: 윈도우 내 현재 요청 수 (ZADD 후 ZCARD)
+   */
+  private static final String SLIDING_WINDOW_SCRIPT = """
+    local key = KEYS[1]
+    local now = tonumber(ARGV[1])
+    local windowStart = tonumber(ARGV[2])
+    local member = ARGV[3]
+    local limit = tonumber(ARGV[4])
+    local ttl = tonumber(ARGV[5])
+                
+    -- 윈도우 밖 항목 제거
+    redis.call('ZREMRANGEBYSCORE', key, '-inf', windowStart)
+                
+    -- 현재 윈도우 내 요청 수 조회
+    local count = redis.call('ZCARD', key)
+                
+    -- 한도 초과 시 즉시 반환 (ZADD 없이)
+    if count >= limit then
+        return count + 1
+    end
+                
+    -- 요청 기록 추가
+    redis.call('ZADD', key, now, member)
+                
+    -- TTL 갱신 (윈도우 시간으로 자동 정리)
+    redis.call('EXPIRE', key, ttl)
+                
+    return count + 1
+    """;
+
+  private static final DefaultRedisScript<Long> REDIS_SCRIPT;
+
+  static {
+    REDIS_SCRIPT = new DefaultRedisScript<>();
+    REDIS_SCRIPT.setScriptText(SLIDING_WINDOW_SCRIPT);
+    REDIS_SCRIPT.setResultType(Long.class);
+  }
+
+  /**
+   * Rate Limit 검사 및 요청 기록
+   *
+   * <p>허용 횟수 초과 시 RATE_LIMIT_EXCEEDED (429) 예외를 던진다.
+   * <p>Redis 장애 시에는 fail-open 정책으로 요청을 통과시킨다.
+   * Rate Limit은 보조 보호 장치이며, 핵심 예약/결제 정합성은 DB Lock, 상태 전이 가드,
+   * Idempotency Key로 보호한다.
+   *
+   * @param memberId      인증된 사용자 ID
+   * @param api           적용 대상 API 식별자
+   * @param limit         윈도우 내 허용 최대 횟수
+   * @param windowSeconds 슬라이딩 윈도우 크기 (초)
+   */
+  public void check(Long memberId, RateLimitApi api, int limit, int windowSeconds) {
+    if (memberId == null || api == null) {
+      throw new IllegalArgumentException("memberId and api must not be null");
+    }
+
+    if (limit <= 0 || windowSeconds <= 0) {
+      throw new IllegalArgumentException("limit and windowSeconds must be positive");
+    }
+
+    String key = buildKey(memberId, api);
+    long now = System.currentTimeMillis();
+    long windowStart = now - (long) windowSeconds * 1000;
+
+    // member: 동일 밀리초 요청 충돌 방지를 위해 UUID 포함
+    String member = now + ":" + UUID.randomUUID();
+
+    Long count;
+    try {
+      count = stringRedisTemplate.execute(
+        REDIS_SCRIPT,
+        List.of(key),
+        String.valueOf(now),
+        String.valueOf(windowStart),
+        member,
+        String.valueOf(limit),
+        String.valueOf(windowSeconds)
+      );
+    } catch (RuntimeException e) {
+      log.error("rate limit redis check failed: memberId={}, api={}", memberId, api, e);
+      return; // fail-open: Rate Limit 장애가 핵심 API 가용성을 막지 않도록 요청을 통과시킨다.
+    }
+
+    if (count != null && count > limit) {
+      log.warn("rate limit exceeded: memberId={}, api={}, count={}, limit={}",
+        memberId, api, count, limit);
+      throw new BusinessException(RateLimitErrorCode.RATE_LIMIT_EXCEEDED);
+    }
+  }
+
+  /**
+   * Redis Key 생성
+   * 형식: rate:limit:{memberId}:{api}
+   * 예: rate:limit:42:HOLD
+   */
+  private String buildKey(Long memberId, RateLimitApi api) {
+    return "rate:limit:" + memberId + ":" + api.name();
+  }
+}

--- a/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
+++ b/src/main/java/com/pil97/ticketing/payment/api/PaymentController.java
@@ -1,5 +1,7 @@
 package com.pil97.ticketing.payment.api;
 
+import com.pil97.ticketing.common.ratelimit.RateLimit;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
 import com.pil97.ticketing.common.response.ApiResponse;
 import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.member.domain.Member;
@@ -23,25 +25,26 @@ public class PaymentController {
 
   /**
    * POST /payments
-   * - Mock 결제를 처리한다.
-   * - 결제 성공 시 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다.
-   * - 결제 실패 시 예약 FAILED, 좌석 AVAILABLE로 복구된다.
-   * - forceFailure: true이면 강제 실패 처리 (실패 시나리오 재현용)
-   * <p>
-   * 멱등성 정책:
-   * - Idempotency-Key 헤더 필수
-   * - 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200)
-   * - 동일 key + 다른 본문 재요청 시 409 반환
-   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리, 나머지 409 반환
-   * - Idempotency-Key 헤더 누락 시 400 에러 (IDEMPOTENCY-003)
+   *
+   * <p>Mock 결제를 처리한다.
+   * 결제 성공 시 예약 CONFIRMED, 좌석 RESERVED, HOLD CONFIRMED로 전환된다.
+   * 결제 실패 시 예약 FAILED, 좌석 AVAILABLE로 복구된다.
+   *
+   * <p>Rate Limit 정책: 60초 윈도우 내 최대 3회
+   * 결제는 외부 시스템 연동을 동반하므로 가장 엄격하게 제한한다.
+   *
+   * <p>멱등성 정책:
+   * Idempotency-Key 헤더 필수.
+   * 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200).
+   * 동일 key + 다른 본문 재요청 시 409 반환.
    */
+  @RateLimit(api = RateLimitApi.PAYMENT, limit = 3, windowSeconds = 60)
   @PostMapping("/payments")
   public ResponseEntity<ApiResponse<PaymentResponse>> pay(
     @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
     @RequestBody @Valid CreatePaymentRequest request) {
 
     IdempotencyResult<PaymentResponse> result = paymentService.pay(idempotencyKey, request);
-
     HttpStatus status = result.isReplayed() ? HttpStatus.OK : HttpStatus.CREATED;
 
     return ResponseEntity
@@ -51,10 +54,10 @@ public class PaymentController {
 
   /**
    * POST /payments/{paymentId}/refund
-   * - 결제 성공(SUCCESS) 상태인 결제에 대해 환불을 처리한다.
-   * - 본인 소유 결제가 아닌 경우 403 반환 (PAYMENT-006)
-   * - SUCCESS 상태가 아닌 결제 환불 시도 시 409 반환 (PAYMENT-005)
-   * - Controller는 요청/응답 변환만 담당 - 소유권/상태 검증은 Service에서 처리
+   *
+   * <p>결제 성공(SUCCESS) 상태인 결제에 대해 환불을 처리한다.
+   * 본인 소유 결제가 아닌 경우 403 반환 (PAYMENT-006).
+   * SUCCESS 상태가 아닌 결제 환불 시도 시 409 반환 (PAYMENT-005).
    */
   @PostMapping("/payments/{paymentId}/refund")
   public ResponseEntity<ApiResponse<PaymentResponse>> refund(

--- a/src/main/java/com/pil97/ticketing/queue/application/QueueService.java
+++ b/src/main/java/com/pil97/ticketing/queue/application/QueueService.java
@@ -49,14 +49,15 @@ public class QueueService {
   /**
    * 대기열 등록 및 재진입
    * <p>
-   * 최초 등록: ZADD NX로 순번 발급
-   * 재진입: ZREM → ZADD로 기존 순번 초기화 후 맨 뒤 재등록
+   * 최초 등록: ZADD NX(score=0)로 등록 선점 → 성공 시에만 INCR로 score 발급 후 교체
+   * 재진입: INCR로 새 score 발급 후 ZADD로 맨 뒤 재등록
    * 존재하지 않는 eventId 요청 시 QueueErrorCode.EVENT_NOT_FOUND 예외 발생
    *
    * @param eventId  이벤트 ID
    * @param memberId JWT에서 추출한 회원 ID
    * @return 순번(1 - based), 예상 대기 시간(초)
    */
+
   public QueueEnterResponse enter(Long eventId, Long memberId) {
 
     // 이벤트 존재 여부 확인
@@ -64,17 +65,29 @@ public class QueueService {
       throw new BusinessException(QueueErrorCode.EVENT_NOT_FOUND);
     }
 
-    // Redis INCR 기반 전역 카운터로 score 충돌 완전 방지
-    double score = queueRepository.nextScore(eventId);
     boolean isReEnter = queueRepository.hasAdmittedHistory(eventId, memberId);
 
     if (isReEnter) {
-      // 재진입: 기존 순번 초기화 후 맨 뒤 재등록
+      // 재진입은 기존 대기열 위치를 초기화하고 맨 뒤로 보내야 하므로 새 score를 발급한다.
+      double score = queueRepository.nextScore(eventId);
       queueRepository.addOrReplace(eventId, memberId, score);
       log.info("memberId={} action=QUEUE_REENTERED eventId={}", memberId, eventId);
     } else {
-      // 최초 등록: 이미 대기열에 있으면 기존 순번 유지
-      queueRepository.addIfAbsent(eventId, memberId, score);
+      /*
+       * 최초 등록은 이미 대기열에 있는 사용자의 기존 순번을 유지해야 한다.
+       * 따라서 먼저 ZADD NX로 등록 성공 여부를 확인하고,
+       * 실제로 새로 등록된 경우에만 INCR로 score를 발급한다.
+       *
+       * 주의:
+       * 등록 성공 여부와 무관하게 nextScore()를 먼저 호출하면
+       * 중복 등록 시도만으로 queue:seq:{eventId}가 증가해 score가 건너뛸 수 있다.
+       */
+      boolean added = queueRepository.addIfAbsent(eventId, memberId, 0);
+
+      if (added) {
+        double score = queueRepository.nextScore(eventId);
+        queueRepository.addOrReplace(eventId, memberId, score);
+      }
     }
 
     // 활성 대기열 이벤트 목록에 등록 - 스케줄러가 이 Set을 순회하며 처리

--- a/src/main/java/com/pil97/ticketing/reservation/api/ReservationController.java
+++ b/src/main/java/com/pil97/ticketing/reservation/api/ReservationController.java
@@ -1,5 +1,7 @@
 package com.pil97.ticketing.reservation.api;
 
+import com.pil97.ticketing.common.ratelimit.RateLimit;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
 import com.pil97.ticketing.common.response.ApiResponse;
 import com.pil97.ticketing.infra.idempotency.IdempotencyResult;
 import com.pil97.ticketing.reservation.api.dto.response.ReservationResponse;
@@ -19,27 +21,24 @@ public class ReservationController {
 
   /**
    * POST /holds/{holdId}/reserve
-   * <p>
-   * 이 API의 목적:
-   * - 유효한 HOLD를 기반으로 결제 대기 상태의 예약(PENDING)을 생성한다.
-   * - 좌석 상태와 HOLD 상태 전이는 결제 완료(PaymentService) 시점에 처리된다.
-   * <p>
-   * 상태코드 정책:
-   * - 예약 확정 성공 시 201 Created
-   * <p>
-   * 멱등성 정책:
-   * - Idempotency-Key 헤더 필수
-   * - 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200)
-   * - 동일 key + 다른 본문 재요청 시 409 반환
-   * - 동시 신규 요청 시 SETNX lock으로 1건만 처리, 나머지 409 반환
+   *
+   * <p>유효한 HOLD를 기반으로 결제 대기 상태의 예약(PENDING)을 생성한다.
+   *
+   * <p>Rate Limit 정책: 60초 윈도우 내 최대 3회
+   * 예약 생성은 DB 상태 전이를 동반하므로 HOLD보다 엄격하게 제한한다.
+   *
+   * <p>멱등성 정책:
+   * Idempotency-Key 헤더 필수.
+   * 동일 key + 동일 본문 재요청 시 기존 응답 반환 (HTTP 200).
+   * 동일 key + 다른 본문 재요청 시 409 반환.
    */
+  @RateLimit(api = RateLimitApi.RESERVATION, limit = 3, windowSeconds = 60)
   @PostMapping("/holds/{holdId}/reserve")
   public ResponseEntity<ApiResponse<ReservationResponse>> reserve(
     @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
     @PathVariable Long holdId) {
 
     IdempotencyResult<ReservationResponse> result = reservationService.reserve(idempotencyKey, holdId);
-
     HttpStatus status = result.isReplayed() ? HttpStatus.OK : HttpStatus.CREATED;
 
     return ResponseEntity
@@ -49,9 +48,9 @@ public class ReservationController {
 
   /**
    * DELETE /reservations/{reservationId}
-   * - 예약 확정된 좌석을 취소한다
-   * - 성공 시 좌석 상태 AVAILABLE로 복구, 예약 상태 CANCELLED로 변경
-   * - 204 No Content
+   *
+   * <p>예약 확정된 좌석을 취소한다.
+   * 성공 시 좌석 상태 AVAILABLE로 복구, 예약 상태 CANCELLED로 변경.
    */
   @DeleteMapping("/reservations/{reservationId}")
   public ResponseEntity<Void> cancel(@PathVariable Long reservationId) {

--- a/src/test/java/com/pil97/ticketing/infra/ratelimit/RateLimitServiceIntegrationTest.java
+++ b/src/test/java/com/pil97/ticketing/infra/ratelimit/RateLimitServiceIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.pil97.ticketing.infra.ratelimit;
+
+import com.pil97.ticketing.common.error.RateLimitErrorCode;
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RateLimitService Redis 연동 테스트
+ *
+ * <p>Mockito로는 실제 Lua Script 원자성과 슬라이딩 윈도우 동작을 보장할 수 없다.
+ * 실제 Redis를 사용해 윈도우 내 카운트, 초과 차단, 윈도우 만료, 동시 요청 처리를 검증한다.
+ */
+@ActiveProfiles("test")
+@SpringBootTest
+class RateLimitServiceIntegrationTest {
+
+  @Autowired
+  private RateLimitService rateLimitService;
+
+  @Autowired
+  private StringRedisTemplate redisTemplate;
+
+  private static final Long MEMBER_ID = 9999L;
+  private static final Long OTHER_MEMBER_ID = 8888L;
+  private static final RateLimitApi API = RateLimitApi.HOLD;
+
+  @AfterEach
+  void tearDown() {
+    // 테스트 후 잔여 key 정리
+    redisTemplate.delete("rate:limit:" + MEMBER_ID + ":" + API.name());
+    redisTemplate.delete("rate:limit:" + OTHER_MEMBER_ID + ":" + API.name());
+  }
+
+  @Test
+  @DisplayName("허용 횟수 이하 요청은 모두 통과한다")
+  void check_withinLimit_allPass() {
+    // when & then - limit 3, 3번 요청 모두 통과
+    for (int i = 0; i < 3; i++) {
+      rateLimitService.check(MEMBER_ID, API, 3, 60);
+    }
+  }
+
+  @Test
+  @DisplayName("허용 횟수 초과 요청은 RATE_LIMIT_EXCEEDED 예외를 던진다")
+  void check_exceedsLimit_throwsException() {
+    // given - limit 3, 3번 통과
+    for (int i = 0; i < 3; i++) {
+      rateLimitService.check(MEMBER_ID, API, 3, 60);
+    }
+
+    // when & then - 4번째 요청 차단
+    assertThatThrownBy(() ->
+      rateLimitService.check(MEMBER_ID, API, 3, 60)
+    )
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(RateLimitErrorCode.RATE_LIMIT_EXCEEDED);
+      });
+  }
+
+  @Test
+  @DisplayName("다른 memberId는 독립적으로 카운트를 관리한다")
+  void check_differentMembers_independentCount() {
+    // given - MEMBER_ID는 이미 한도 초과
+    for (int i = 0; i < 3; i++) {
+      rateLimitService.check(MEMBER_ID, API, 3, 60);
+    }
+
+    // when & then - OTHER_MEMBER_ID는 영향 없이 통과
+    rateLimitService.check(OTHER_MEMBER_ID, API, 3, 60);
+  }
+
+  @Test
+  @DisplayName("윈도우(1초) 경과 후 요청은 카운트가 초기화되어 통과한다")
+  void check_afterWindowExpires_countResets() throws InterruptedException {
+    // given - windowSeconds=1, limit=2로 한도 채움
+    rateLimitService.check(MEMBER_ID, API, 2, 1);
+    rateLimitService.check(MEMBER_ID, API, 2, 1);
+
+    // when - 윈도우(1초) 대기
+    Thread.sleep(1100);
+
+    // then - 윈도우 만료 후 통과
+    rateLimitService.check(MEMBER_ID, API, 2, 1);
+  }
+
+  @Test
+  @DisplayName("동시 요청 시 Lua Script 원자성으로 정확하게 카운트된다")
+  void check_concurrentRequests_atomicCount() throws InterruptedException {
+    int threadCount = 10;
+    int limit = 5;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    AtomicInteger passCount = new AtomicInteger(0);
+    AtomicInteger rejectCount = new AtomicInteger(0);
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          rateLimitService.check(MEMBER_ID, API, limit, 60);
+          passCount.incrementAndGet();
+        } catch (BusinessException e) {
+          rejectCount.incrementAndGet();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+
+    assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+    executor.shutdown();
+
+    // limit=5, 10개 요청 → 정확히 5개 통과, 5개 차단
+    assertThat(passCount.get()).isEqualTo(limit);
+    assertThat(rejectCount.get()).isEqualTo(threadCount - limit);
+  }
+}

--- a/src/test/java/com/pil97/ticketing/infra/ratelimit/RateLimitServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/infra/ratelimit/RateLimitServiceTest.java
@@ -1,0 +1,113 @@
+package com.pil97.ticketing.infra.ratelimit;
+
+import com.pil97.ticketing.common.error.RateLimitErrorCode;
+import com.pil97.ticketing.common.exception.BusinessException;
+import com.pil97.ticketing.common.ratelimit.RateLimitApi;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitServiceTest {
+
+  @Mock
+  private StringRedisTemplate stringRedisTemplate;
+
+  @InjectMocks
+  private RateLimitService rateLimitService;
+
+  private static final Long MEMBER_ID = 1L;
+  private static final RateLimitApi API = RateLimitApi.HOLD;
+  private static final int LIMIT = 5;
+  private static final int WINDOW_SECONDS = 60;
+
+  @Test
+  @DisplayName("api가 null이면 IllegalArgumentException을 던진다")
+  void check_nullApi_throwsIllegalArgument() {
+    assertThatThrownBy(() ->
+      rateLimitService.check(MEMBER_ID, null, LIMIT, WINDOW_SECONDS)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("windowSeconds가 0 이하이면 IllegalArgumentException을 던진다")
+  void check_invalidWindowSeconds_throwsIllegalArgument() {
+    assertThatThrownBy(() ->
+      rateLimitService.check(MEMBER_ID, API, LIMIT, 0)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("윈도우 내 요청 수가 한도 이하이면 예외 없이 통과한다")
+  void check_withinLimit_doesNotThrow() {
+    // given - 현재 요청 수 3 (limit 5 이하)
+    given(stringRedisTemplate.execute(
+      ArgumentMatchers.<DefaultRedisScript<Long>>any(), anyList(), any(Object[].class))
+    ).willReturn(3L);
+
+    // when & then
+    assertThatCode(() ->
+      rateLimitService.check(MEMBER_ID, API, LIMIT, WINDOW_SECONDS)
+    ).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("윈도우 내 요청 수가 한도를 초과하면 RATE_LIMIT_EXCEEDED 예외를 던진다")
+  void check_exceedsLimit_throwsRateLimitExceeded() {
+    // given - 현재 요청 수 6 (limit 5 초과)
+    given(stringRedisTemplate.execute(
+      ArgumentMatchers.<DefaultRedisScript<Long>>any(), anyList(), any(Object[].class))
+    ).willReturn(6L);
+
+    // when & then
+    assertThatThrownBy(() ->
+      rateLimitService.check(MEMBER_ID, API, LIMIT, WINDOW_SECONDS)
+    )
+      .isInstanceOf(BusinessException.class)
+      .satisfies(ex -> {
+        BusinessException be = (BusinessException) ex;
+        assertThat(be.getErrorCode()).isEqualTo(RateLimitErrorCode.RATE_LIMIT_EXCEEDED);
+      });
+  }
+
+  @Test
+  @DisplayName("Redis 장애 시 fail-open 정책으로 예외 없이 통과한다")
+  void check_redisFailure_failOpen() {
+    // given - Redis 장애 시뮬레이션
+    given(stringRedisTemplate.execute(
+      ArgumentMatchers.<DefaultRedisScript<Long>>any(), anyList(), any(Object[].class))
+    ).willThrow(new RuntimeException("Redis connection refused"));
+
+    // when & then - fail-open: 요청 통과
+    assertThatCode(() ->
+      rateLimitService.check(MEMBER_ID, API, LIMIT, WINDOW_SECONDS)
+    ).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("memberId가 null이면 IllegalArgumentException을 던진다")
+  void check_nullMemberId_throwsIllegalArgument() {
+    assertThatThrownBy(() ->
+      rateLimitService.check(null, API, LIMIT, WINDOW_SECONDS)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("limit이 0 이하이면 IllegalArgumentException을 던진다")
+  void check_invalidLimit_throwsIllegalArgument() {
+    assertThatThrownBy(() ->
+      rateLimitService.check(MEMBER_ID, API, 0, WINDOW_SECONDS)
+    ).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/com/pil97/ticketing/queue/application/QueueConcurrencyTest.java
+++ b/src/test/java/com/pil97/ticketing/queue/application/QueueConcurrencyTest.java
@@ -1,5 +1,6 @@
 package com.pil97.ticketing.queue.application;
 
+import com.pil97.ticketing.event.domain.repository.EventRepository;
 import com.pil97.ticketing.queue.application.scheduler.QueueScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,12 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 
 /**
  * 테스트 흐름 설명
@@ -25,10 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 2. Redis Sorted Set ZADD NX로 각 memberId가 중복 없이 등록되는지 검증
  * 3. 등록된 유저 수 == 100, 순번 중복 없음 검증
  * <p>
- * EventRepository mock 제거 이유:
- * - @BeforeEach의 Mockito stub은 메인 스레드 기준으로 등록되므로 워커 스레드에서 보장되지 않는다.
- * - 동시성 테스트의 목적은 Redis Sorted Set 동시 접근 안정성 검증이므로 DB는 실제 환경을 사용한다.
- * - @BeforeEach에서 jdbcTemplate으로 실제 seed 데이터의 eventId를 조회하므로 mock이 불필요하다.
+ * EventRepository mock 이유:
+ * 100개 스레드가 동시에 existsById() DB 쿼리를 실행하면 HikariCP 커넥션 풀이
+ * 고갈되어 done.await() 타임아웃이 발생할 수 있다.
+ * 이 테스트의 목적은 Redis Sorted Set 동시 접근 안정성 검증이므로
+ * DB 호출은 mock으로 처리한다.
  */
 @ActiveProfiles("test")
 @SpringBootTest
@@ -37,6 +42,10 @@ class QueueConcurrencyTest {
   // QueueScheduler가 테스트 중 실행되면 대기열에서 멤버를 제거해 순번 검증이 깨지므로 MockitoBean으로 비활성화
   @MockitoBean
   private QueueScheduler queueScheduler;
+
+  // EventRepository mock 이유: 위 클래스 주석 참조
+  @MockitoBean
+  private EventRepository eventRepository;
 
   @Autowired
   private QueueService queueService;
@@ -62,6 +71,8 @@ class QueueConcurrencyTest {
     redisTemplate.delete("queue:seq:" + eventId);
     // queue:active:events에서 해당 eventId 제거 - 테스트 간 잔여 데이터 방지
     redisTemplate.opsForSet().remove("queue:active:events", String.valueOf(eventId));
+
+    given(eventRepository.existsById(anyLong())).willReturn(true);
   }
 
   @Test
@@ -95,19 +106,29 @@ class QueueConcurrencyTest {
       });
     }
 
-    ready.await();     // 모든 스레드 준비될 때까지 대기
-    start.countDown(); // 동시 출발
-    done.await();      // 모든 스레드 완료될 때까지 대기
+    assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+    start.countDown();
+    assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
     executor.shutdown();
+    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
 
     // then - 100명 전원 성공
     assertThat(successCount.get()).isEqualTo(threadCount);
     assertThat(failCount.get()).isEqualTo(0);
 
     // Redis Sorted Set에 100개 등록 확인
-    Set<String> members = redisTemplate.opsForZSet()
-      .range("queue:event:" + eventId, 0, -1);
-    assertThat(members).hasSize(threadCount);
+    Set<org.springframework.data.redis.core.ZSetOperations.TypedTuple<String>> tuples =
+      redisTemplate.opsForZSet()
+        .rangeWithScores("queue:event:" + eventId, 0, -1);
+
+    assertThat(tuples).hasSize(threadCount);
+
+// score(순번) 중복 체크
+    Set<Double> scores = new java.util.HashSet<>();
+    for (var t : tuples) {
+      scores.add(t.getScore());
+    }
+    assertThat(scores).hasSize(threadCount);
   }
 
   @Test
@@ -135,10 +156,11 @@ class QueueConcurrencyTest {
       });
     }
 
-    ready.await();
+    assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
     start.countDown();
-    done.await();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
     executor.shutdown();
+    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
 
     // then - 동일 memberId는 Sorted Set에 1개만 존재해야 함
     Long rank = redisTemplate.opsForZSet()

--- a/src/test/java/com/pil97/ticketing/queue/application/QueueServiceTest.java
+++ b/src/test/java/com/pil97/ticketing/queue/application/QueueServiceTest.java
@@ -78,8 +78,8 @@ class QueueServiceTest {
     assertThat(response.rank()).isEqualTo(5L);
     assertThat(response.estimatedWaitSeconds()).isGreaterThanOrEqualTo(0L);
 
-    verify(queueRepository).addIfAbsent(eq(eventId), eq(memberId), anyDouble());
-    verify(queueRepository, never()).addOrReplace(anyLong(), anyLong(), anyDouble());
+    verify(queueRepository).addIfAbsent(eq(eventId), eq(memberId), eq(0d));
+    verify(queueRepository).addOrReplace(eq(eventId), eq(memberId), anyDouble());
   }
 
   @Test
@@ -94,7 +94,6 @@ class QueueServiceTest {
     when(queueRepository.hasAdmittedHistory(eventId, memberId)).thenReturn(false);
     when(queueRepository.addIfAbsent(eq(eventId), eq(memberId), anyDouble())).thenReturn(false);
     when(queueRepository.getRank(eventId, memberId)).thenReturn(2L);
-    when(queueRepository.nextScore(eventId)).thenReturn(1L);
 
     // when
     QueueEnterResponse response = queueService.enter(eventId, memberId);


### PR DESCRIPTION
## What

* `common/ratelimit`: `@RateLimit`(어노테이션), `RateLimitApi`(enum) 추가
* `common/error`: `RateLimitErrorCode`(`RATE_LIMIT_EXCEEDED`, 429) 추가
* `infra/ratelimit`: `RateLimitAspect`(AOP), `RateLimitService`(슬라이딩 윈도우 구현체) 추가
* `hold/api`: `HoldController`에 `@RateLimit` 적용 (5회/60초)
* `reservation/api`: `ReservationController`에 `@RateLimit` 적용 (3회/60초)
* `payment/api`: `PaymentController`에 `@RateLimit` 적용 (3회/60초)
* `queue/application`: `QueueService.enter()` score 발급 순서 개선
* `test/infra/ratelimit`: `RateLimitServiceTest`, `RateLimitServiceIntegrationTest` 추가
* `test/queue/application`: `QueueServiceTest`, `QueueConcurrencyTest` 수정
* `PROJECT-RULES.md`: Redis Key Naming 테이블에 `rate:limit:{memberId}:{api}` 추가
* `README.md`: Rate Limiting 개요, 기술 결정, 구현 현황, 에러코드 정책 반영

## Why

* HOLD/예약/결제 API는 DB Lock, Redis, 결제 상태 변경을 동반한다. 악의적 반복 요청 또는 클라이언트 버그로 인한 폭발적 요청이 발생할 경우 서버 전체에 영향을 미칠 수 있어 사용자별 요청 횟수 제한이 필요했다.
* Idempotency Key(TASK-052)로 중복 처리는 막을 수 있지만, 요청 자체의 빈도 제한은 별도 레이어가 필요하다.

## How

* **슬라이딩 윈도우 방식 선택**: 고정 윈도우는 경계에서 최대 2배 요청이 허용될 수 있다. 슬라이딩 윈도우는 Sorted Set으로 요청 타임스탬프를 관리해 현재 시점 기준 윈도우 내 요청 수를 제한한다.
* **Lua Script 원자성**: `ZREMRANGEBYSCORE → ZCARD → ZADD → EXPIRE` 4개 명령을 개별 실행하면 동시 요청에서 카운트 검사와 추가 사이에 경쟁 조건이 발생할 수 있다. Lua Script로 묶어 원자적으로 처리한다.
* **AOP 기반 적용**: `@RateLimit` 어노테이션 선언만으로 Rate Limit 정책을 적용할 수 있도록 AOP를 사용해 Controller 코드 변경을 최소화했다.
* **fail-open 정책**: Rate Limit은 보조 보호 장치이므로 Redis 장애 시 요청을 통과시킨다. 핵심 정합성은 DB Lock, 상태 전이 가드, Idempotency Key가 담당한다.
* **QueueService 개선**: TASK-031 전체 테스트 수행 중 `QueueConcurrencyTest` 실패를 재현했다. `nextScore()`를 등록 성공 전에 호출하면 중복 등록 시도만으로 `queue:seq`가 증가해 score가 건너뛸 수 있어, `addIfAbsent` 성공 시에만 score를 발급하도록 수정했다.
* **QueueConcurrencyTest 안정화**: 100개 스레드가 동시에 `existsById()` DB 쿼리를 실행할 경우 HikariCP 커넥션 풀이 고갈되어 테스트 타임아웃이 발생할 수 있었다. Redis Sorted Set 동시 접근 검증이라는 테스트 목적에 맞게 `EventRepository`를 mock 처리했다.

## Test

* `./gradlew clean test -Dspring.profiles.active=test` 통과
* 추가된 테스트

  * `RateLimitServiceTest`: 허용/초과/fail-open/파라미터 검증 7개 케이스
  * `RateLimitServiceIntegrationTest`: 실제 Redis 기반 허용/초과/윈도우 만료/사용자별 독립 카운트/동시 요청 원자성 5개 케이스
* 수동 테스트(Postman)

  * `POST /showtimes/{showtimeId}/hold` 연속 요청 시 6번째 요청부터 `429 RATE-LIMIT-001` 응답 확인

## Notes

> TASK-031 작업 중 발견한 기존 이슈

* `QueueService` score 발급 순서 개선 및 `QueueConcurrencyTest` Flaky 수정을 이 PR에 함께 포함했다.
* Rate Limit 허용 횟수(HOLD 5회, 예약·결제 3회)는 운영 로그 기반 최종값이 아닌 초기 보호 정책값이다. 실제 운영 데이터와 부하 테스트 결과를 기반으로 조정할 수 있도록 어노테이션 파라미터로 분리했다.

closes #96 
